### PR TITLE
Add automatic mapping and history

### DIFF
--- a/provider/cmd/pulumi-resource-acme/bridge-metadata.json
+++ b/provider/cmd/pulumi-resource-acme/bridge-metadata.json
@@ -1,0 +1,109 @@
+{
+    "auto-aliasing": {
+        "resources": {
+            "acme_certificate": {
+                "current": "acme:index/certificate:Certificate",
+                "fields": {
+                    "dns_challenge": {
+                        "maxItemsOne": false
+                    },
+                    "http_challenge": {
+                        "maxItemsOne": true
+                    },
+                    "http_memcached_challenge": {
+                        "maxItemsOne": true,
+                        "elem": {
+                            "fields": {
+                                "hosts": {
+                                    "maxItemsOne": false
+                                }
+                            }
+                        }
+                    },
+                    "http_webroot_challenge": {
+                        "maxItemsOne": true
+                    },
+                    "recursive_nameservers": {
+                        "maxItemsOne": false
+                    },
+                    "subject_alternative_names": {
+                        "maxItemsOne": false
+                    },
+                    "tls_challenge": {
+                        "maxItemsOne": true
+                    }
+                }
+            },
+            "acme_registration": {
+                "current": "acme:index/registration:Registration",
+                "fields": {
+                    "external_account_binding": {
+                        "maxItemsOne": true
+                    }
+                }
+            }
+        },
+        "datasources": {
+            "acme_certificate": {
+                "current": "acme:index/getCertificate:getCertificate"
+            },
+            "acme_registration": {
+                "current": "acme:index/getRegistration:getRegistration"
+            }
+        }
+    },
+    "renames": {
+        "resources": {
+            "acme:index/certificate:Certificate": "acme_certificate",
+            "acme:index/registration:Registration": "acme_registration"
+        },
+        "renamedProperties": {
+            "acme:index/CertificateHttpChallenge:CertificateHttpChallenge": {
+                "proxyHeader": "proxy_header"
+            },
+            "acme:index/RegistrationExternalAccountBinding:RegistrationExternalAccountBinding": {
+                "hmacBase64": "hmac_base64",
+                "keyId": "key_id"
+            },
+            "acme:index/certificate:Certificate": {
+                "accountKeyPem": "account_key_pem",
+                "certificateDomain": "certificate_domain",
+                "certificateNotAfter": "certificate_not_after",
+                "certificateP12": "certificate_p12",
+                "certificateP12Password": "certificate_p12_password",
+                "certificatePem": "certificate_pem",
+                "certificateRequestPem": "certificate_request_pem",
+                "certificateUrl": "certificate_url",
+                "commonName": "common_name",
+                "disableCompletePropagation": "disable_complete_propagation",
+                "dnsChallenges": "dns_challenge",
+                "httpChallenge": "http_challenge",
+                "httpMemcachedChallenge": "http_memcached_challenge",
+                "httpWebrootChallenge": "http_webroot_challenge",
+                "issuerPem": "issuer_pem",
+                "keyType": "key_type",
+                "minDaysRemaining": "min_days_remaining",
+                "mustStaple": "must_staple",
+                "preCheckDelay": "pre_check_delay",
+                "preferredChain": "preferred_chain",
+                "privateKeyPem": "private_key_pem",
+                "recursiveNameservers": "recursive_nameservers",
+                "revokeCertificateOnDestroy": "revoke_certificate_on_destroy",
+                "subjectAlternativeNames": "subject_alternative_names",
+                "tlsChallenge": "tls_challenge"
+            },
+            "acme:index/registration:Registration": {
+                "accountKeyPem": "account_key_pem",
+                "emailAddress": "email_address",
+                "externalAccountBinding": "external_account_binding",
+                "registrationUrl": "registration_url"
+            },
+            "acme:index:Provider": {
+                "serverUrl": "server_url"
+            }
+        },
+        "renamedConfigProperties": {
+            "serverUrl": "server_url"
+        }
+    }
+}


### PR DESCRIPTION
`prov.MustComputeTokens` will automatically map new resource and datasources. `prov.MustApplyAutoAliases` will apply MaxItemsOne and naming history, preventing breaking some categories of breaking changes from upstream.

These are flags that are set on providers that the provider team maintains.