### PR TITLE
SDKs with docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # ACME Resource Provider
 
-The ACME Resource Provider lets you manage [ACME](http://example.com) resources.
+The ACME Resource Provider lets you manage ACME resources. 
+[Let's Encrypt](https://letsencrypt.org/) is the biggest ACME CA in use.
 
 ## Installing
 
@@ -11,13 +12,13 @@ This package is available for several languages/platforms:
 To use from JavaScript or TypeScript in Node.js, install using either `npm`:
 
 ```bash
-npm install @pulumi/acme
+npm install @pulumiverse/acme
 ```
 
 or `yarn`:
 
 ```bash
-yarn add @pulumi/acme
+yarn add @pulumiverse/acme
 ```
 
 ### Python
@@ -25,7 +26,7 @@ yarn add @pulumi/acme
 To use from Python, install using `pip`:
 
 ```bash
-pip install pulumi_acme
+pip install pulumiverse_acme
 ```
 
 ### Go
@@ -33,7 +34,7 @@ pip install pulumi_acme
 To use from Go, use `go get` to grab the latest version of the library:
 
 ```bash
-go get github.com/pulumi/pulumi-acme/sdk/go/...
+go get github.com/pulumiverse/pulumi-acme/sdk/go/...
 ```
 
 ### .NET
@@ -41,15 +42,8 @@ go get github.com/pulumi/pulumi-acme/sdk/go/...
 To use from .NET, install using `dotnet add package`:
 
 ```bash
-dotnet add package Pulumi.ACME
+dotnet add package Pulumiverse.Acme
 ```
-
-## Configuration
-
-The following configuration points are available for the `acme` provider:
-
-- `acme:apiKey` (environment: `ACME_API_KEY`) - the API key for `acme`
-- `acme:region` (environment: `ACME_REGION`) - the region in which to deploy resources
 
 ## Reference
 

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -1,0 +1,176 @@
+---
+title: ACME
+meta_desc: Provides an overview of the ACME Provider for Pulumi.
+layout: package
+---
+
+The Automated Certificate Management Environment (ACME) is an evolving standard
+for the automation of a domain-validated certificate authority. Clients register
+themselves on an authority using a private key and contact information, and
+answer challenges for domains that they own by supplying response data issued by
+the authority via either HTTP or DNS. Via this process, they prove that they own
+the domains in question, and can then request certificates for them via the CA.
+No part of this process requires user interaction, a traditional blocker in
+obtaining a domain validated certificate.
+
+Currently the major ACME CA is [Let's Encrypt][lets-encrypt], but the ACME
+support in Pulumi can be configured to use any ACME CA, including an
+internal one that is set up using [Boulder][boulder-gh], or another CA
+that implements the ACME standard with Let's Encrypt's
+[divergences][lets-encrypt-divergences].
+
+[lets-encrypt]: https://letsencrypt.org
+[boulder-gh]: https://github.com/letsencrypt/boulder
+[lets-encrypt-divergences]: https://github.com/letsencrypt/boulder/blob/master/docs/acme-divergences.md
+
+For more detail on the ACME process, see [here][lets-encrypt-how-it-works]. For
+the ACME spec, click [here][about-acme]. Note that as mentioned in the last
+paragraph, the ACME provider may [diverge][lets-encrypt-divergences] from the
+current ACME spec to account for the real-world divergences that are made by
+CAs such as Let's Encrypt.
+
+[lets-encrypt-how-it-works]: https://letsencrypt.org/how-it-works/
+[about-acme]: https://ietf-wg-acme.github.io/acme/draft-ietf-acme-acme.html
+
+## Example
+
+{{< chooser language "typescript,python,go,csharp" >}}
+{{% choosable language typescript %}}
+
+```typescript
+import * as pulumi from "@pulumi/pulumi";
+import * as acme from "@pulumiverse/acme";
+import * as tls from "@pulumi/tls";
+
+const privateKey = new tls.index.PrivateKey("privateKey", {algorithm: "RSA"});
+
+const reg = new acme.index.Registration("reg", {
+    accountKeyPem: privateKey.privateKeyPem,
+    emailAddress: "nobody@example.com",
+});
+const certificate = new acme.index.Certificate("certificate", {
+    accountKeyPem: reg.accountKeyPem,
+    commonName: "www.example.com",
+    subjectAlternativeNames: ["www2.example.com"],
+    dnsChallenge: [{
+        provider: "route53",
+    }],
+});
+```
+ 
+{{% /choosable %}}
+{{% choosable language python %}}
+
+```python
+import pulumi
+import pulumiverse_acme as acme
+import pulumi_tls as tls
+
+private_key = tls.index.PrivateKey("privateKey", algorithm="RSA")
+
+reg = acme.index.Registration("reg",
+    account_key_pem=private_key.private_key_pem,
+    email_address="nobody@example.com")
+
+certificate = acme.index.Certificate("certificate",
+    account_key_pem=reg.account_key_pem,
+    common_name="www.example.com",
+    subject_alternative_names=["www2.example.com"],
+    dns_challenge=[{
+        provider="route53",
+    }])
+```
+
+{{% /choosable %}}
+{{% choosable language go %}}
+
+```go
+package main
+
+import (
+	"github.com/pulumi/pulumi-tls/sdk/v4/go/tls"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumiverse/pulumi-acme/sdk/go/acme"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		privateKey, err := tls.NewPrivateKey(ctx, "privateKey", &tls.PrivateKeyArgs{
+			Algorithm: "RSA",
+		})
+		if err != nil {
+			return err
+		}
+		reg, err := acme.NewRegistration(ctx, "reg", &acme.RegistrationArgs{
+			AccountKeyPem: privateKey.PrivateKeyPem,
+			EmailAddress:  "nobody@example.com",
+		})
+		if err != nil {
+			return err
+		}
+		_, err = acme.NewCertificate(ctx, "certificate", &acme.CertificateArgs{
+			AccountKeyPem: reg.AccountKeyPem,
+			CommonName:    "www.example.com",
+			SubjectAlternativeNames: []string{
+				"www2.example.com",
+			},
+			DnsChallenge: []map[string]interface{}{
+				map[string]interface{}{
+					"provider": "route53",
+				},
+			},
+		})
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+}
+```
+
+{{% /choosable %}}
+{{% choosable language csharp %}}
+
+```csharp
+using System.Collections.Generic;
+using System.Linq;
+using Pulumi;
+using Acme = Pulumiverse.Acme;
+using Tls = Pulumi.Tls;
+
+return await Deployment.RunAsync(() => 
+{
+    var privateKey = new Tls.Index.PrivateKey("privateKey", new()
+    {
+        Algorithm = "RSA",
+    });
+
+    var reg = new Acme.Index.Registration("reg", new()
+    {
+        AccountKeyPem = privateKey.PrivateKeyPem,
+        EmailAddress = "nobody@example.com",
+    });
+
+    var certificate = new Acme.Index.Certificate("certificate", new()
+    {
+        AccountKeyPem = reg.AccountKeyPem,
+        CommonName = "www.example.com",
+        SubjectAlternativeNames = new[]
+        {
+            "www2.example.com",
+        },
+        DnsChallenge = new[]
+        {
+            
+            {
+                { "provider", "route53" },
+            },
+        },
+    });
+
+});
+```
+
+{{% /choosable %}}
+
+{{< /chooser >}}

--- a/docs/installation-configuration.md
+++ b/docs/installation-configuration.md
@@ -1,0 +1,26 @@
+---
+title: Acme Installation & Configuration
+meta_desc: Information on how to install the Acme provider.
+layout: package
+---
+
+## Installation
+
+The Pulumiverse Acme provider is available as a package in all Pulumi languages:
+
+* JavaScript/TypeScript: [`@pulumiverse/acme`](https://www.npmjs.com/package/@pulumiverse/acme)
+* Python: [`pulumiverse_acme`](https://pypi.org/project/pulumiverse-acme/)
+* Go: [`github.com/pulumiverse/pulumi-acme/sdk/go/acme`](https://pkg.go.dev/github.com/pulumiverse/pulumi-acme/sdk)
+* .NET: [`Pulumiverse.Acme`](https://www.nuget.org/packages/Pulumiverse.Acme)
+
+## Setup
+
+To provision resources with the Pulumi Acme provider, you need to have correct ACME endpoint configuration.
+
+## Configuration Options
+
+Use `pulumi config set acme:<option> (--secret)`.
+
+| Option | Environment Variable | Required/Optional | Description | 
+|-----|------|------|----|
+| `serverUrl`|  | Required | ACME CA endpoint URL |

--- a/sdk/dotnet/Certificate.cs
+++ b/sdk/dotnet/Certificate.cs
@@ -13,78 +13,237 @@ namespace Pulumiverse.Acme
     [AcmeResourceType("acme:index/certificate:Certificate")]
     public partial class Certificate : global::Pulumi.CustomResource
     {
+        /// <summary>
+        /// The private key of the account that is
+        /// requesting the certificate. Forces a new resource when changed.
+        /// </summary>
         [Output("accountKeyPem")]
         public Output<string> AccountKeyPem { get; private set; } = null!;
 
+        /// <summary>
+        /// The common name of the certificate.
+        /// </summary>
         [Output("certificateDomain")]
         public Output<string> CertificateDomain { get; private set; } = null!;
 
+        /// <summary>
+        /// The expiry date of the certificate, laid out in
+        /// RFC3339 format (`2006-01-02T15:04:05Z07:00`).
+        /// </summary>
         [Output("certificateNotAfter")]
         public Output<string> CertificateNotAfter { get; private set; } = null!;
 
+        /// <summary>
+        /// The certificate, any intermediates, and the private key
+        /// archived as a PFX file (PKCS12 format, generally used by Microsoft products).
+        /// The data is base64 encoded (including padding), and its password is
+        /// configurable via the `certificate_p12_password`
+        /// argument. This field is empty if creating a certificate from a CSR.
+        /// </summary>
         [Output("certificateP12")]
         public Output<string> CertificateP12 { get; private set; } = null!;
 
+        /// <summary>
+        /// Password to be used when generating
+        /// the PFX file stored in `certificate_p12`. Defaults to an
+        /// empty string.
+        /// </summary>
         [Output("certificateP12Password")]
         public Output<string?> CertificateP12Password { get; private set; } = null!;
 
+        /// <summary>
+        /// The certificate in PEM format. This does not include the
+        /// `issuer_pem`. This certificate can be concatenated with `issuer_pem` to form
+        /// a full chain, e.g. `"${acme_certificate.certificate.certificate_pem}${acme_certificate.certificate.issuer_pem}"`
+        /// </summary>
         [Output("certificatePem")]
         public Output<string> CertificatePem { get; private set; } = null!;
 
+        /// <summary>
+        /// A pre-created certificate request, such as one
+        /// from [`tls_cert_request`][tls-cert-request], or one from an external source,
+        /// in PEM format.  Either this, or the in-resource request options
+        /// (`common_name`, `key_type`, and optionally `subject_alternative_names`) need
+        /// to be specified. Forces a new resource when changed.
+        /// </summary>
         [Output("certificateRequestPem")]
         public Output<string?> CertificateRequestPem { get; private set; } = null!;
 
+        /// <summary>
+        /// The full URL of the certificate within the ACME CA.
+        /// </summary>
         [Output("certificateUrl")]
         public Output<string> CertificateUrl { get; private set; } = null!;
 
+        /// <summary>
+        /// The certificate's common name, the primary domain that the
+        /// certificate will be recognized for. Required when not specifying a CSR. Forces
+        /// a new resource when changed.
+        /// </summary>
         [Output("commonName")]
         public Output<string?> CommonName { get; private set; } = null!;
 
+        /// <summary>
+        /// Disable the requirement for full
+        /// propagation of the TXT challenge records before proceeding with validation.
+        /// Defaults to `false`.
+        /// 
+        /// &gt; See About DNS propagation checks for details
+        /// on the `recursive_nameservers` and `disable_complete_propagation` settings.
+        /// </summary>
         [Output("disableCompletePropagation")]
         public Output<bool?> DisableCompletePropagation { get; private set; } = null!;
 
+        /// <summary>
+        /// The DNS challenges to
+        /// use in fulfilling the request.
+        /// </summary>
         [Output("dnsChallenges")]
         public Output<ImmutableArray<Outputs.CertificateDnsChallenge>> DnsChallenges { get; private set; } = null!;
 
+        /// <summary>
+        /// Defines an HTTP challenge to use in fulfilling
+        /// the request.
+        /// </summary>
         [Output("httpChallenge")]
         public Output<Outputs.CertificateHttpChallenge?> HttpChallenge { get; private set; } = null!;
 
+        /// <summary>
+        /// Defines an alternate type of HTTP
+        /// challenge that can be used to serve up challenges to a
+        /// [Memcached](https://memcached.org/) cluster.
+        /// </summary>
         [Output("httpMemcachedChallenge")]
         public Output<Outputs.CertificateHttpMemcachedChallenge?> HttpMemcachedChallenge { get; private set; } = null!;
 
+        /// <summary>
+        /// Defines an alternate type of HTTP
+        /// challenge that can be used to place a file at a location that can be served by
+        /// an out-of-band webserver.
+        /// </summary>
         [Output("httpWebrootChallenge")]
         public Output<Outputs.CertificateHttpWebrootChallenge?> HttpWebrootChallenge { get; private set; } = null!;
 
+        /// <summary>
+        /// The intermediate certificates of the issuer. Multiple
+        /// certificates are concatenated in this field when there is more than one
+        /// intermediate certificate in the chain.
+        /// </summary>
         [Output("issuerPem")]
         public Output<string> IssuerPem { get; private set; } = null!;
 
+        /// <summary>
+        /// The key type for the certificate's private key. Can be one of:
+        /// `P256` and `P384` (for ECDSA keys of respective length) or `2048`, `4096`, and
+        /// `8192` (for RSA keys of respective length). Required when not specifying a
+        /// CSR. The default is `2048` (RSA key of 2048 bits). Forces a new resource when
+        /// changed.
+        /// </summary>
         [Output("keyType")]
         public Output<string?> KeyType { get; private set; } = null!;
 
+        /// <summary>
+        /// The minimum amount of days remaining on the
+        /// expiration of a certificate before a renewal is attempted. The default is
+        /// `30`. A value of less than `0` means that the certificate will never be
+        /// renewed.
+        /// </summary>
         [Output("minDaysRemaining")]
         public Output<int?> MinDaysRemaining { get; private set; } = null!;
 
+        /// <summary>
+        /// Enables the [OCSP Stapling Required][ocsp-stapling]
+        /// TLS Security Policy extension. Certificates with this extension must include a
+        /// valid OCSP Staple in the TLS handshake for the connection to succeed.
+        /// Defaults to `false`. Note that this option has no effect when using an
+        /// external CSR - it must be enabled in the CSR itself. Forces a new resource
+        /// when changed.
+        /// 
+        /// [ocsp-stapling]: https://letsencrypt.org/docs/integration-guide/#implement-ocsp-stapling
+        /// 
+        /// &gt; OCSP stapling requires specific webserver configuration to support the
+        /// downloading of the staple from the CA's OCSP endpoints, and should be configured
+        /// to tolerate prolonged outages of the OCSP service. Consider this when using
+        /// `must_staple`, and only enable it if you are sure your webserver or service
+        /// provider can be configured correctly.
+        /// </summary>
         [Output("mustStaple")]
         public Output<bool?> MustStaple { get; private set; } = null!;
 
+        /// <summary>
+        /// Insert a delay after _every_ DNS challenge
+        /// record to allow for extra time for DNS propagation before the certificate is
+        /// requested. Use this option if you observe issues with requesting certificates
+        /// even when DNS challenge records get added successfully. Units are in seconds.
+        /// Defaults to 0 (no delay).
+        /// 
+        /// &gt; Be careful with `pre_check_delay` since the delay is executed _per-domain_.
+        /// Take your expected delay and divide it by the number of domains you have
+        /// configured (`common_name` + `subject_alternative_names`).
+        /// </summary>
         [Output("preCheckDelay")]
         public Output<int?> PreCheckDelay { get; private set; } = null!;
 
+        /// <summary>
+        /// The common name of the root of a preferred
+        /// alternate certificate chain offered by the CA. The certificates in
+        /// `issuer_pem` will reflect the chain requested, if available, otherwise the
+        /// default chain will be provided. Forces a new resource when changed.
+        /// 
+        /// &gt; `preferred_chain` can be used to request alternate chains on Let's Encrypt
+        /// during the transition away from their old cross-signed intermediates. See [this
+        /// article for more
+        /// details](https://letsencrypt.org/2020/12/21/extending-android-compatibility.html).
+        /// In their example titled **"What about the alternate chain?"**, the root you
+        /// would put in to the `preferred_chain` field would be `ISRG Root X1`. The
+        /// equivalent in the [staging
+        /// environment](https://letsencrypt.org/docs/staging-environment/) is `(STAGING)
+        /// Pretend Pear X1`.
+        /// </summary>
         [Output("preferredChain")]
         public Output<string?> PreferredChain { get; private set; } = null!;
 
+        /// <summary>
+        /// The certificate's private key, in PEM format, if the
+        /// certificate was generated from scratch and not with
+        /// `certificate_request_pem`.  If
+        /// `certificate_request_pem` was used, this will be blank.
+        /// </summary>
         [Output("privateKeyPem")]
         public Output<string> PrivateKeyPem { get; private set; } = null!;
 
+        /// <summary>
+        /// The recursive nameservers that will be
+        /// used to check for propagation of DNS challenge records. Defaults to your
+        /// system-configured DNS resolvers.
+        /// </summary>
         [Output("recursiveNameservers")]
         public Output<ImmutableArray<string>> RecursiveNameservers { get; private set; } = null!;
 
+        /// <summary>
+        /// Enables revocation of a certificate upon destroy,
+        /// which includes when a resource is re-created. Default is `true`.
+        /// </summary>
         [Output("revokeCertificateOnDestroy")]
         public Output<bool?> RevokeCertificateOnDestroy { get; private set; } = null!;
 
+        /// <summary>
+        /// The certificate's subject alternative names,
+        /// domains that this certificate will also be recognized for. Only valid when not
+        /// specifying a CSR. Forces a new resource when changed.
+        /// </summary>
         [Output("subjectAlternativeNames")]
         public Output<ImmutableArray<string>> SubjectAlternativeNames { get; private set; } = null!;
 
+        /// <summary>
+        /// Defines a TLS challenge to use in fulfilling the
+        /// request.
+        /// 
+        /// &gt; Only one of `http_challenge`, `http_webroot_challenge`, and
+        /// `http_memcached_challenge` can be defined at once. See the section on Using
+        /// HTTP and TLS challenges for more details on
+        /// using these and `tls_challenge`.
+        /// </summary>
         [Output("tlsChallenge")]
         public Output<Outputs.CertificateTlsChallenge?> TlsChallenge { get; private set; } = null!;
 
@@ -144,6 +303,11 @@ namespace Pulumiverse.Acme
     {
         [Input("accountKeyPem", required: true)]
         private Input<string>? _accountKeyPem;
+
+        /// <summary>
+        /// The private key of the account that is
+        /// requesting the certificate. Forces a new resource when changed.
+        /// </summary>
         public Input<string>? AccountKeyPem
         {
             get => _accountKeyPem;
@@ -156,6 +320,12 @@ namespace Pulumiverse.Acme
 
         [Input("certificateP12Password")]
         private Input<string>? _certificateP12Password;
+
+        /// <summary>
+        /// Password to be used when generating
+        /// the PFX file stored in `certificate_p12`. Defaults to an
+        /// empty string.
+        /// </summary>
         public Input<string>? CertificateP12Password
         {
             get => _certificateP12Password;
@@ -166,66 +336,186 @@ namespace Pulumiverse.Acme
             }
         }
 
+        /// <summary>
+        /// A pre-created certificate request, such as one
+        /// from [`tls_cert_request`][tls-cert-request], or one from an external source,
+        /// in PEM format.  Either this, or the in-resource request options
+        /// (`common_name`, `key_type`, and optionally `subject_alternative_names`) need
+        /// to be specified. Forces a new resource when changed.
+        /// </summary>
         [Input("certificateRequestPem")]
         public Input<string>? CertificateRequestPem { get; set; }
 
+        /// <summary>
+        /// The certificate's common name, the primary domain that the
+        /// certificate will be recognized for. Required when not specifying a CSR. Forces
+        /// a new resource when changed.
+        /// </summary>
         [Input("commonName")]
         public Input<string>? CommonName { get; set; }
 
+        /// <summary>
+        /// Disable the requirement for full
+        /// propagation of the TXT challenge records before proceeding with validation.
+        /// Defaults to `false`.
+        /// 
+        /// &gt; See About DNS propagation checks for details
+        /// on the `recursive_nameservers` and `disable_complete_propagation` settings.
+        /// </summary>
         [Input("disableCompletePropagation")]
         public Input<bool>? DisableCompletePropagation { get; set; }
 
         [Input("dnsChallenges")]
         private InputList<Inputs.CertificateDnsChallengeArgs>? _dnsChallenges;
+
+        /// <summary>
+        /// The DNS challenges to
+        /// use in fulfilling the request.
+        /// </summary>
         public InputList<Inputs.CertificateDnsChallengeArgs> DnsChallenges
         {
             get => _dnsChallenges ?? (_dnsChallenges = new InputList<Inputs.CertificateDnsChallengeArgs>());
             set => _dnsChallenges = value;
         }
 
+        /// <summary>
+        /// Defines an HTTP challenge to use in fulfilling
+        /// the request.
+        /// </summary>
         [Input("httpChallenge")]
         public Input<Inputs.CertificateHttpChallengeArgs>? HttpChallenge { get; set; }
 
+        /// <summary>
+        /// Defines an alternate type of HTTP
+        /// challenge that can be used to serve up challenges to a
+        /// [Memcached](https://memcached.org/) cluster.
+        /// </summary>
         [Input("httpMemcachedChallenge")]
         public Input<Inputs.CertificateHttpMemcachedChallengeArgs>? HttpMemcachedChallenge { get; set; }
 
+        /// <summary>
+        /// Defines an alternate type of HTTP
+        /// challenge that can be used to place a file at a location that can be served by
+        /// an out-of-band webserver.
+        /// </summary>
         [Input("httpWebrootChallenge")]
         public Input<Inputs.CertificateHttpWebrootChallengeArgs>? HttpWebrootChallenge { get; set; }
 
+        /// <summary>
+        /// The key type for the certificate's private key. Can be one of:
+        /// `P256` and `P384` (for ECDSA keys of respective length) or `2048`, `4096`, and
+        /// `8192` (for RSA keys of respective length). Required when not specifying a
+        /// CSR. The default is `2048` (RSA key of 2048 bits). Forces a new resource when
+        /// changed.
+        /// </summary>
         [Input("keyType")]
         public Input<string>? KeyType { get; set; }
 
+        /// <summary>
+        /// The minimum amount of days remaining on the
+        /// expiration of a certificate before a renewal is attempted. The default is
+        /// `30`. A value of less than `0` means that the certificate will never be
+        /// renewed.
+        /// </summary>
         [Input("minDaysRemaining")]
         public Input<int>? MinDaysRemaining { get; set; }
 
+        /// <summary>
+        /// Enables the [OCSP Stapling Required][ocsp-stapling]
+        /// TLS Security Policy extension. Certificates with this extension must include a
+        /// valid OCSP Staple in the TLS handshake for the connection to succeed.
+        /// Defaults to `false`. Note that this option has no effect when using an
+        /// external CSR - it must be enabled in the CSR itself. Forces a new resource
+        /// when changed.
+        /// 
+        /// [ocsp-stapling]: https://letsencrypt.org/docs/integration-guide/#implement-ocsp-stapling
+        /// 
+        /// &gt; OCSP stapling requires specific webserver configuration to support the
+        /// downloading of the staple from the CA's OCSP endpoints, and should be configured
+        /// to tolerate prolonged outages of the OCSP service. Consider this when using
+        /// `must_staple`, and only enable it if you are sure your webserver or service
+        /// provider can be configured correctly.
+        /// </summary>
         [Input("mustStaple")]
         public Input<bool>? MustStaple { get; set; }
 
+        /// <summary>
+        /// Insert a delay after _every_ DNS challenge
+        /// record to allow for extra time for DNS propagation before the certificate is
+        /// requested. Use this option if you observe issues with requesting certificates
+        /// even when DNS challenge records get added successfully. Units are in seconds.
+        /// Defaults to 0 (no delay).
+        /// 
+        /// &gt; Be careful with `pre_check_delay` since the delay is executed _per-domain_.
+        /// Take your expected delay and divide it by the number of domains you have
+        /// configured (`common_name` + `subject_alternative_names`).
+        /// </summary>
         [Input("preCheckDelay")]
         public Input<int>? PreCheckDelay { get; set; }
 
+        /// <summary>
+        /// The common name of the root of a preferred
+        /// alternate certificate chain offered by the CA. The certificates in
+        /// `issuer_pem` will reflect the chain requested, if available, otherwise the
+        /// default chain will be provided. Forces a new resource when changed.
+        /// 
+        /// &gt; `preferred_chain` can be used to request alternate chains on Let's Encrypt
+        /// during the transition away from their old cross-signed intermediates. See [this
+        /// article for more
+        /// details](https://letsencrypt.org/2020/12/21/extending-android-compatibility.html).
+        /// In their example titled **"What about the alternate chain?"**, the root you
+        /// would put in to the `preferred_chain` field would be `ISRG Root X1`. The
+        /// equivalent in the [staging
+        /// environment](https://letsencrypt.org/docs/staging-environment/) is `(STAGING)
+        /// Pretend Pear X1`.
+        /// </summary>
         [Input("preferredChain")]
         public Input<string>? PreferredChain { get; set; }
 
         [Input("recursiveNameservers")]
         private InputList<string>? _recursiveNameservers;
+
+        /// <summary>
+        /// The recursive nameservers that will be
+        /// used to check for propagation of DNS challenge records. Defaults to your
+        /// system-configured DNS resolvers.
+        /// </summary>
         public InputList<string> RecursiveNameservers
         {
             get => _recursiveNameservers ?? (_recursiveNameservers = new InputList<string>());
             set => _recursiveNameservers = value;
         }
 
+        /// <summary>
+        /// Enables revocation of a certificate upon destroy,
+        /// which includes when a resource is re-created. Default is `true`.
+        /// </summary>
         [Input("revokeCertificateOnDestroy")]
         public Input<bool>? RevokeCertificateOnDestroy { get; set; }
 
         [Input("subjectAlternativeNames")]
         private InputList<string>? _subjectAlternativeNames;
+
+        /// <summary>
+        /// The certificate's subject alternative names,
+        /// domains that this certificate will also be recognized for. Only valid when not
+        /// specifying a CSR. Forces a new resource when changed.
+        /// </summary>
         public InputList<string> SubjectAlternativeNames
         {
             get => _subjectAlternativeNames ?? (_subjectAlternativeNames = new InputList<string>());
             set => _subjectAlternativeNames = value;
         }
 
+        /// <summary>
+        /// Defines a TLS challenge to use in fulfilling the
+        /// request.
+        /// 
+        /// &gt; Only one of `http_challenge`, `http_webroot_challenge`, and
+        /// `http_memcached_challenge` can be defined at once. See the section on Using
+        /// HTTP and TLS challenges for more details on
+        /// using these and `tls_challenge`.
+        /// </summary>
         [Input("tlsChallenge")]
         public Input<Inputs.CertificateTlsChallengeArgs>? TlsChallenge { get; set; }
 
@@ -239,6 +529,11 @@ namespace Pulumiverse.Acme
     {
         [Input("accountKeyPem")]
         private Input<string>? _accountKeyPem;
+
+        /// <summary>
+        /// The private key of the account that is
+        /// requesting the certificate. Forces a new resource when changed.
+        /// </summary>
         public Input<string>? AccountKeyPem
         {
             get => _accountKeyPem;
@@ -249,14 +544,29 @@ namespace Pulumiverse.Acme
             }
         }
 
+        /// <summary>
+        /// The common name of the certificate.
+        /// </summary>
         [Input("certificateDomain")]
         public Input<string>? CertificateDomain { get; set; }
 
+        /// <summary>
+        /// The expiry date of the certificate, laid out in
+        /// RFC3339 format (`2006-01-02T15:04:05Z07:00`).
+        /// </summary>
         [Input("certificateNotAfter")]
         public Input<string>? CertificateNotAfter { get; set; }
 
         [Input("certificateP12")]
         private Input<string>? _certificateP12;
+
+        /// <summary>
+        /// The certificate, any intermediates, and the private key
+        /// archived as a PFX file (PKCS12 format, generally used by Microsoft products).
+        /// The data is base64 encoded (including padding), and its password is
+        /// configurable via the `certificate_p12_password`
+        /// argument. This field is empty if creating a certificate from a CSR.
+        /// </summary>
         public Input<string>? CertificateP12
         {
             get => _certificateP12;
@@ -269,6 +579,12 @@ namespace Pulumiverse.Acme
 
         [Input("certificateP12Password")]
         private Input<string>? _certificateP12Password;
+
+        /// <summary>
+        /// Password to be used when generating
+        /// the PFX file stored in `certificate_p12`. Defaults to an
+        /// empty string.
+        /// </summary>
         public Input<string>? CertificateP12Password
         {
             get => _certificateP12Password;
@@ -279,58 +595,173 @@ namespace Pulumiverse.Acme
             }
         }
 
+        /// <summary>
+        /// The certificate in PEM format. This does not include the
+        /// `issuer_pem`. This certificate can be concatenated with `issuer_pem` to form
+        /// a full chain, e.g. `"${acme_certificate.certificate.certificate_pem}${acme_certificate.certificate.issuer_pem}"`
+        /// </summary>
         [Input("certificatePem")]
         public Input<string>? CertificatePem { get; set; }
 
+        /// <summary>
+        /// A pre-created certificate request, such as one
+        /// from [`tls_cert_request`][tls-cert-request], or one from an external source,
+        /// in PEM format.  Either this, or the in-resource request options
+        /// (`common_name`, `key_type`, and optionally `subject_alternative_names`) need
+        /// to be specified. Forces a new resource when changed.
+        /// </summary>
         [Input("certificateRequestPem")]
         public Input<string>? CertificateRequestPem { get; set; }
 
+        /// <summary>
+        /// The full URL of the certificate within the ACME CA.
+        /// </summary>
         [Input("certificateUrl")]
         public Input<string>? CertificateUrl { get; set; }
 
+        /// <summary>
+        /// The certificate's common name, the primary domain that the
+        /// certificate will be recognized for. Required when not specifying a CSR. Forces
+        /// a new resource when changed.
+        /// </summary>
         [Input("commonName")]
         public Input<string>? CommonName { get; set; }
 
+        /// <summary>
+        /// Disable the requirement for full
+        /// propagation of the TXT challenge records before proceeding with validation.
+        /// Defaults to `false`.
+        /// 
+        /// &gt; See About DNS propagation checks for details
+        /// on the `recursive_nameservers` and `disable_complete_propagation` settings.
+        /// </summary>
         [Input("disableCompletePropagation")]
         public Input<bool>? DisableCompletePropagation { get; set; }
 
         [Input("dnsChallenges")]
         private InputList<Inputs.CertificateDnsChallengeGetArgs>? _dnsChallenges;
+
+        /// <summary>
+        /// The DNS challenges to
+        /// use in fulfilling the request.
+        /// </summary>
         public InputList<Inputs.CertificateDnsChallengeGetArgs> DnsChallenges
         {
             get => _dnsChallenges ?? (_dnsChallenges = new InputList<Inputs.CertificateDnsChallengeGetArgs>());
             set => _dnsChallenges = value;
         }
 
+        /// <summary>
+        /// Defines an HTTP challenge to use in fulfilling
+        /// the request.
+        /// </summary>
         [Input("httpChallenge")]
         public Input<Inputs.CertificateHttpChallengeGetArgs>? HttpChallenge { get; set; }
 
+        /// <summary>
+        /// Defines an alternate type of HTTP
+        /// challenge that can be used to serve up challenges to a
+        /// [Memcached](https://memcached.org/) cluster.
+        /// </summary>
         [Input("httpMemcachedChallenge")]
         public Input<Inputs.CertificateHttpMemcachedChallengeGetArgs>? HttpMemcachedChallenge { get; set; }
 
+        /// <summary>
+        /// Defines an alternate type of HTTP
+        /// challenge that can be used to place a file at a location that can be served by
+        /// an out-of-band webserver.
+        /// </summary>
         [Input("httpWebrootChallenge")]
         public Input<Inputs.CertificateHttpWebrootChallengeGetArgs>? HttpWebrootChallenge { get; set; }
 
+        /// <summary>
+        /// The intermediate certificates of the issuer. Multiple
+        /// certificates are concatenated in this field when there is more than one
+        /// intermediate certificate in the chain.
+        /// </summary>
         [Input("issuerPem")]
         public Input<string>? IssuerPem { get; set; }
 
+        /// <summary>
+        /// The key type for the certificate's private key. Can be one of:
+        /// `P256` and `P384` (for ECDSA keys of respective length) or `2048`, `4096`, and
+        /// `8192` (for RSA keys of respective length). Required when not specifying a
+        /// CSR. The default is `2048` (RSA key of 2048 bits). Forces a new resource when
+        /// changed.
+        /// </summary>
         [Input("keyType")]
         public Input<string>? KeyType { get; set; }
 
+        /// <summary>
+        /// The minimum amount of days remaining on the
+        /// expiration of a certificate before a renewal is attempted. The default is
+        /// `30`. A value of less than `0` means that the certificate will never be
+        /// renewed.
+        /// </summary>
         [Input("minDaysRemaining")]
         public Input<int>? MinDaysRemaining { get; set; }
 
+        /// <summary>
+        /// Enables the [OCSP Stapling Required][ocsp-stapling]
+        /// TLS Security Policy extension. Certificates with this extension must include a
+        /// valid OCSP Staple in the TLS handshake for the connection to succeed.
+        /// Defaults to `false`. Note that this option has no effect when using an
+        /// external CSR - it must be enabled in the CSR itself. Forces a new resource
+        /// when changed.
+        /// 
+        /// [ocsp-stapling]: https://letsencrypt.org/docs/integration-guide/#implement-ocsp-stapling
+        /// 
+        /// &gt; OCSP stapling requires specific webserver configuration to support the
+        /// downloading of the staple from the CA's OCSP endpoints, and should be configured
+        /// to tolerate prolonged outages of the OCSP service. Consider this when using
+        /// `must_staple`, and only enable it if you are sure your webserver or service
+        /// provider can be configured correctly.
+        /// </summary>
         [Input("mustStaple")]
         public Input<bool>? MustStaple { get; set; }
 
+        /// <summary>
+        /// Insert a delay after _every_ DNS challenge
+        /// record to allow for extra time for DNS propagation before the certificate is
+        /// requested. Use this option if you observe issues with requesting certificates
+        /// even when DNS challenge records get added successfully. Units are in seconds.
+        /// Defaults to 0 (no delay).
+        /// 
+        /// &gt; Be careful with `pre_check_delay` since the delay is executed _per-domain_.
+        /// Take your expected delay and divide it by the number of domains you have
+        /// configured (`common_name` + `subject_alternative_names`).
+        /// </summary>
         [Input("preCheckDelay")]
         public Input<int>? PreCheckDelay { get; set; }
 
+        /// <summary>
+        /// The common name of the root of a preferred
+        /// alternate certificate chain offered by the CA. The certificates in
+        /// `issuer_pem` will reflect the chain requested, if available, otherwise the
+        /// default chain will be provided. Forces a new resource when changed.
+        /// 
+        /// &gt; `preferred_chain` can be used to request alternate chains on Let's Encrypt
+        /// during the transition away from their old cross-signed intermediates. See [this
+        /// article for more
+        /// details](https://letsencrypt.org/2020/12/21/extending-android-compatibility.html).
+        /// In their example titled **"What about the alternate chain?"**, the root you
+        /// would put in to the `preferred_chain` field would be `ISRG Root X1`. The
+        /// equivalent in the [staging
+        /// environment](https://letsencrypt.org/docs/staging-environment/) is `(STAGING)
+        /// Pretend Pear X1`.
+        /// </summary>
         [Input("preferredChain")]
         public Input<string>? PreferredChain { get; set; }
 
         [Input("privateKeyPem")]
         private Input<string>? _privateKeyPem;
+
+        /// <summary>
+        /// The certificate's private key, in PEM format, if the
+        /// certificate was generated from scratch and not with
+        /// `certificate_request_pem`.  If
+        /// `certificate_request_pem` was used, this will be blank.
+        /// </summary>
         public Input<string>? PrivateKeyPem
         {
             get => _privateKeyPem;
@@ -343,23 +774,48 @@ namespace Pulumiverse.Acme
 
         [Input("recursiveNameservers")]
         private InputList<string>? _recursiveNameservers;
+
+        /// <summary>
+        /// The recursive nameservers that will be
+        /// used to check for propagation of DNS challenge records. Defaults to your
+        /// system-configured DNS resolvers.
+        /// </summary>
         public InputList<string> RecursiveNameservers
         {
             get => _recursiveNameservers ?? (_recursiveNameservers = new InputList<string>());
             set => _recursiveNameservers = value;
         }
 
+        /// <summary>
+        /// Enables revocation of a certificate upon destroy,
+        /// which includes when a resource is re-created. Default is `true`.
+        /// </summary>
         [Input("revokeCertificateOnDestroy")]
         public Input<bool>? RevokeCertificateOnDestroy { get; set; }
 
         [Input("subjectAlternativeNames")]
         private InputList<string>? _subjectAlternativeNames;
+
+        /// <summary>
+        /// The certificate's subject alternative names,
+        /// domains that this certificate will also be recognized for. Only valid when not
+        /// specifying a CSR. Forces a new resource when changed.
+        /// </summary>
         public InputList<string> SubjectAlternativeNames
         {
             get => _subjectAlternativeNames ?? (_subjectAlternativeNames = new InputList<string>());
             set => _subjectAlternativeNames = value;
         }
 
+        /// <summary>
+        /// Defines a TLS challenge to use in fulfilling the
+        /// request.
+        /// 
+        /// &gt; Only one of `http_challenge`, `http_webroot_challenge`, and
+        /// `http_memcached_challenge` can be defined at once. See the section on Using
+        /// HTTP and TLS challenges for more details on
+        /// using these and `tls_challenge`.
+        /// </summary>
         [Input("tlsChallenge")]
         public Input<Inputs.CertificateTlsChallengeGetArgs>? TlsChallenge { get; set; }
 

--- a/sdk/dotnet/Inputs/CertificateHttpChallengeArgs.cs
+++ b/sdk/dotnet/Inputs/CertificateHttpChallengeArgs.cs
@@ -13,9 +13,27 @@ namespace Pulumiverse.Acme.Inputs
 
     public sealed class CertificateHttpChallengeArgs : global::Pulumi.ResourceArgs
     {
+        /// <summary>
+        /// The port that the challenge server listens on. Default: `80`.
+        /// </summary>
         [Input("port")]
         public Input<int>? Port { get; set; }
 
+        /// <summary>
+        /// The proxy header to match against. Default:
+        /// `Host`.
+        /// 
+        /// The `proxy_header` option behaves differently depending on its definition:
+        /// 
+        /// * When set to `Host`, standard host header validation is used.
+        /// * When set to `Forwarded`, the server looks in the `Forwarded` header for a
+        /// section matching `host=DOMAIN` where `DOMAIN` is the domain currently being
+        /// resolved by the challenge. See [RFC 7239](https://tools.ietf.org/html/rfc7239)
+        /// for more details.
+        /// * When set to an arbitrary header (example: `X-Forwarded-Host`), that header is
+        /// checked for the host entry in the same way the host header would normally be
+        /// checked.
+        /// </summary>
         [Input("proxyHeader")]
         public Input<string>? ProxyHeader { get; set; }
 

--- a/sdk/dotnet/Inputs/CertificateHttpChallengeGetArgs.cs
+++ b/sdk/dotnet/Inputs/CertificateHttpChallengeGetArgs.cs
@@ -13,9 +13,27 @@ namespace Pulumiverse.Acme.Inputs
 
     public sealed class CertificateHttpChallengeGetArgs : global::Pulumi.ResourceArgs
     {
+        /// <summary>
+        /// The port that the challenge server listens on. Default: `80`.
+        /// </summary>
         [Input("port")]
         public Input<int>? Port { get; set; }
 
+        /// <summary>
+        /// The proxy header to match against. Default:
+        /// `Host`.
+        /// 
+        /// The `proxy_header` option behaves differently depending on its definition:
+        /// 
+        /// * When set to `Host`, standard host header validation is used.
+        /// * When set to `Forwarded`, the server looks in the `Forwarded` header for a
+        /// section matching `host=DOMAIN` where `DOMAIN` is the domain currently being
+        /// resolved by the challenge. See [RFC 7239](https://tools.ietf.org/html/rfc7239)
+        /// for more details.
+        /// * When set to an arbitrary header (example: `X-Forwarded-Host`), that header is
+        /// checked for the host entry in the same way the host header would normally be
+        /// checked.
+        /// </summary>
         [Input("proxyHeader")]
         public Input<string>? ProxyHeader { get; set; }
 

--- a/sdk/dotnet/Inputs/CertificateHttpMemcachedChallengeArgs.cs
+++ b/sdk/dotnet/Inputs/CertificateHttpMemcachedChallengeArgs.cs
@@ -15,6 +15,10 @@ namespace Pulumiverse.Acme.Inputs
     {
         [Input("hosts", required: true)]
         private InputList<string>? _hosts;
+
+        /// <summary>
+        /// The hosts to publish the record to.
+        /// </summary>
         public InputList<string> Hosts
         {
             get => _hosts ?? (_hosts = new InputList<string>());

--- a/sdk/dotnet/Inputs/CertificateHttpMemcachedChallengeGetArgs.cs
+++ b/sdk/dotnet/Inputs/CertificateHttpMemcachedChallengeGetArgs.cs
@@ -15,6 +15,10 @@ namespace Pulumiverse.Acme.Inputs
     {
         [Input("hosts", required: true)]
         private InputList<string>? _hosts;
+
+        /// <summary>
+        /// The hosts to publish the record to.
+        /// </summary>
         public InputList<string> Hosts
         {
             get => _hosts ?? (_hosts = new InputList<string>());

--- a/sdk/dotnet/Inputs/CertificateHttpWebrootChallengeArgs.cs
+++ b/sdk/dotnet/Inputs/CertificateHttpWebrootChallengeArgs.cs
@@ -13,6 +13,9 @@ namespace Pulumiverse.Acme.Inputs
 
     public sealed class CertificateHttpWebrootChallengeArgs : global::Pulumi.ResourceArgs
     {
+        /// <summary>
+        /// The directory to publish the record to.
+        /// </summary>
         [Input("directory", required: true)]
         public Input<string> Directory { get; set; } = null!;
 

--- a/sdk/dotnet/Inputs/CertificateHttpWebrootChallengeGetArgs.cs
+++ b/sdk/dotnet/Inputs/CertificateHttpWebrootChallengeGetArgs.cs
@@ -13,6 +13,9 @@ namespace Pulumiverse.Acme.Inputs
 
     public sealed class CertificateHttpWebrootChallengeGetArgs : global::Pulumi.ResourceArgs
     {
+        /// <summary>
+        /// The directory to publish the record to.
+        /// </summary>
         [Input("directory", required: true)]
         public Input<string> Directory { get; set; } = null!;
 

--- a/sdk/dotnet/Inputs/CertificateTlsChallengeArgs.cs
+++ b/sdk/dotnet/Inputs/CertificateTlsChallengeArgs.cs
@@ -13,6 +13,9 @@ namespace Pulumiverse.Acme.Inputs
 
     public sealed class CertificateTlsChallengeArgs : global::Pulumi.ResourceArgs
     {
+        /// <summary>
+        /// The port that the challenge server listens on. Default: `443`.
+        /// </summary>
         [Input("port")]
         public Input<int>? Port { get; set; }
 

--- a/sdk/dotnet/Inputs/CertificateTlsChallengeGetArgs.cs
+++ b/sdk/dotnet/Inputs/CertificateTlsChallengeGetArgs.cs
@@ -13,6 +13,9 @@ namespace Pulumiverse.Acme.Inputs
 
     public sealed class CertificateTlsChallengeGetArgs : global::Pulumi.ResourceArgs
     {
+        /// <summary>
+        /// The port that the challenge server listens on. Default: `443`.
+        /// </summary>
         [Input("port")]
         public Input<int>? Port { get; set; }
 

--- a/sdk/dotnet/Outputs/CertificateHttpChallenge.cs
+++ b/sdk/dotnet/Outputs/CertificateHttpChallenge.cs
@@ -14,7 +14,25 @@ namespace Pulumiverse.Acme.Outputs
     [OutputType]
     public sealed class CertificateHttpChallenge
     {
+        /// <summary>
+        /// The port that the challenge server listens on. Default: `80`.
+        /// </summary>
         public readonly int? Port;
+        /// <summary>
+        /// The proxy header to match against. Default:
+        /// `Host`.
+        /// 
+        /// The `proxy_header` option behaves differently depending on its definition:
+        /// 
+        /// * When set to `Host`, standard host header validation is used.
+        /// * When set to `Forwarded`, the server looks in the `Forwarded` header for a
+        /// section matching `host=DOMAIN` where `DOMAIN` is the domain currently being
+        /// resolved by the challenge. See [RFC 7239](https://tools.ietf.org/html/rfc7239)
+        /// for more details.
+        /// * When set to an arbitrary header (example: `X-Forwarded-Host`), that header is
+        /// checked for the host entry in the same way the host header would normally be
+        /// checked.
+        /// </summary>
         public readonly string? ProxyHeader;
 
         [OutputConstructor]

--- a/sdk/dotnet/Outputs/CertificateHttpMemcachedChallenge.cs
+++ b/sdk/dotnet/Outputs/CertificateHttpMemcachedChallenge.cs
@@ -14,6 +14,9 @@ namespace Pulumiverse.Acme.Outputs
     [OutputType]
     public sealed class CertificateHttpMemcachedChallenge
     {
+        /// <summary>
+        /// The hosts to publish the record to.
+        /// </summary>
         public readonly ImmutableArray<string> Hosts;
 
         [OutputConstructor]

--- a/sdk/dotnet/Outputs/CertificateHttpWebrootChallenge.cs
+++ b/sdk/dotnet/Outputs/CertificateHttpWebrootChallenge.cs
@@ -14,6 +14,9 @@ namespace Pulumiverse.Acme.Outputs
     [OutputType]
     public sealed class CertificateHttpWebrootChallenge
     {
+        /// <summary>
+        /// The directory to publish the record to.
+        /// </summary>
         public readonly string Directory;
 
         [OutputConstructor]

--- a/sdk/dotnet/Outputs/CertificateTlsChallenge.cs
+++ b/sdk/dotnet/Outputs/CertificateTlsChallenge.cs
@@ -14,6 +14,9 @@ namespace Pulumiverse.Acme.Outputs
     [OutputType]
     public sealed class CertificateTlsChallenge
     {
+        /// <summary>
+        /// The port that the challenge server listens on. Default: `443`.
+        /// </summary>
         public readonly int? Port;
 
         [OutputConstructor]

--- a/sdk/go/acme/certificate.go
+++ b/sdk/go/acme/certificate.go
@@ -16,31 +16,140 @@ import (
 type Certificate struct {
 	pulumi.CustomResourceState
 
-	AccountKeyPem              pulumi.StringOutput                        `pulumi:"accountKeyPem"`
-	CertificateDomain          pulumi.StringOutput                        `pulumi:"certificateDomain"`
-	CertificateNotAfter        pulumi.StringOutput                        `pulumi:"certificateNotAfter"`
-	CertificateP12             pulumi.StringOutput                        `pulumi:"certificateP12"`
-	CertificateP12Password     pulumi.StringPtrOutput                     `pulumi:"certificateP12Password"`
-	CertificatePem             pulumi.StringOutput                        `pulumi:"certificatePem"`
-	CertificateRequestPem      pulumi.StringPtrOutput                     `pulumi:"certificateRequestPem"`
-	CertificateUrl             pulumi.StringOutput                        `pulumi:"certificateUrl"`
-	CommonName                 pulumi.StringPtrOutput                     `pulumi:"commonName"`
-	DisableCompletePropagation pulumi.BoolPtrOutput                       `pulumi:"disableCompletePropagation"`
-	DnsChallenges              CertificateDnsChallengeArrayOutput         `pulumi:"dnsChallenges"`
-	HttpChallenge              CertificateHttpChallengePtrOutput          `pulumi:"httpChallenge"`
-	HttpMemcachedChallenge     CertificateHttpMemcachedChallengePtrOutput `pulumi:"httpMemcachedChallenge"`
-	HttpWebrootChallenge       CertificateHttpWebrootChallengePtrOutput   `pulumi:"httpWebrootChallenge"`
-	IssuerPem                  pulumi.StringOutput                        `pulumi:"issuerPem"`
-	KeyType                    pulumi.StringPtrOutput                     `pulumi:"keyType"`
-	MinDaysRemaining           pulumi.IntPtrOutput                        `pulumi:"minDaysRemaining"`
-	MustStaple                 pulumi.BoolPtrOutput                       `pulumi:"mustStaple"`
-	PreCheckDelay              pulumi.IntPtrOutput                        `pulumi:"preCheckDelay"`
-	PreferredChain             pulumi.StringPtrOutput                     `pulumi:"preferredChain"`
-	PrivateKeyPem              pulumi.StringOutput                        `pulumi:"privateKeyPem"`
-	RecursiveNameservers       pulumi.StringArrayOutput                   `pulumi:"recursiveNameservers"`
-	RevokeCertificateOnDestroy pulumi.BoolPtrOutput                       `pulumi:"revokeCertificateOnDestroy"`
-	SubjectAlternativeNames    pulumi.StringArrayOutput                   `pulumi:"subjectAlternativeNames"`
-	TlsChallenge               CertificateTlsChallengePtrOutput           `pulumi:"tlsChallenge"`
+	// The private key of the account that is
+	// requesting the certificate. Forces a new resource when changed.
+	AccountKeyPem pulumi.StringOutput `pulumi:"accountKeyPem"`
+	// The common name of the certificate.
+	CertificateDomain pulumi.StringOutput `pulumi:"certificateDomain"`
+	// The expiry date of the certificate, laid out in
+	// RFC3339 format (`2006-01-02T15:04:05Z07:00`).
+	CertificateNotAfter pulumi.StringOutput `pulumi:"certificateNotAfter"`
+	// The certificate, any intermediates, and the private key
+	// archived as a PFX file (PKCS12 format, generally used by Microsoft products).
+	// The data is base64 encoded (including padding), and its password is
+	// configurable via the `certificateP12Password`
+	// argument. This field is empty if creating a certificate from a CSR.
+	CertificateP12 pulumi.StringOutput `pulumi:"certificateP12"`
+	// Password to be used when generating
+	// the PFX file stored in `certificateP12`. Defaults to an
+	// empty string.
+	CertificateP12Password pulumi.StringPtrOutput `pulumi:"certificateP12Password"`
+	// The certificate in PEM format. This does not include the
+	// `issuerPem`. This certificate can be concatenated with `issuerPem` to form
+	// a full chain, e.g. `"${acme_certificate.certificate.certificate_pem}${acme_certificate.certificate.issuer_pem}"`
+	CertificatePem pulumi.StringOutput `pulumi:"certificatePem"`
+	// A pre-created certificate request, such as one
+	// from [`tlsCertRequest`][tls-cert-request], or one from an external source,
+	// in PEM format.  Either this, or the in-resource request options
+	// (`commonName`, `keyType`, and optionally `subjectAlternativeNames`) need
+	// to be specified. Forces a new resource when changed.
+	CertificateRequestPem pulumi.StringPtrOutput `pulumi:"certificateRequestPem"`
+	// The full URL of the certificate within the ACME CA.
+	CertificateUrl pulumi.StringOutput `pulumi:"certificateUrl"`
+	// The certificate's common name, the primary domain that the
+	// certificate will be recognized for. Required when not specifying a CSR. Forces
+	// a new resource when changed.
+	CommonName pulumi.StringPtrOutput `pulumi:"commonName"`
+	// Disable the requirement for full
+	// propagation of the TXT challenge records before proceeding with validation.
+	// Defaults to `false`.
+	//
+	// > See About DNS propagation checks for details
+	// on the `recursiveNameservers` and `disableCompletePropagation` settings.
+	DisableCompletePropagation pulumi.BoolPtrOutput `pulumi:"disableCompletePropagation"`
+	// The DNS challenges to
+	// use in fulfilling the request.
+	DnsChallenges CertificateDnsChallengeArrayOutput `pulumi:"dnsChallenges"`
+	// Defines an HTTP challenge to use in fulfilling
+	// the request.
+	HttpChallenge CertificateHttpChallengePtrOutput `pulumi:"httpChallenge"`
+	// Defines an alternate type of HTTP
+	// challenge that can be used to serve up challenges to a
+	// [Memcached](https://memcached.org/) cluster.
+	HttpMemcachedChallenge CertificateHttpMemcachedChallengePtrOutput `pulumi:"httpMemcachedChallenge"`
+	// Defines an alternate type of HTTP
+	// challenge that can be used to place a file at a location that can be served by
+	// an out-of-band webserver.
+	HttpWebrootChallenge CertificateHttpWebrootChallengePtrOutput `pulumi:"httpWebrootChallenge"`
+	// The intermediate certificates of the issuer. Multiple
+	// certificates are concatenated in this field when there is more than one
+	// intermediate certificate in the chain.
+	IssuerPem pulumi.StringOutput `pulumi:"issuerPem"`
+	// The key type for the certificate's private key. Can be one of:
+	// `P256` and `P384` (for ECDSA keys of respective length) or `2048`, `4096`, and
+	// `8192` (for RSA keys of respective length). Required when not specifying a
+	// CSR. The default is `2048` (RSA key of 2048 bits). Forces a new resource when
+	// changed.
+	KeyType pulumi.StringPtrOutput `pulumi:"keyType"`
+	// The minimum amount of days remaining on the
+	// expiration of a certificate before a renewal is attempted. The default is
+	// `30`. A value of less than `0` means that the certificate will never be
+	// renewed.
+	MinDaysRemaining pulumi.IntPtrOutput `pulumi:"minDaysRemaining"`
+	// Enables the [OCSP Stapling Required][ocsp-stapling]
+	// TLS Security Policy extension. Certificates with this extension must include a
+	// valid OCSP Staple in the TLS handshake for the connection to succeed.
+	// Defaults to `false`. Note that this option has no effect when using an
+	// external CSR - it must be enabled in the CSR itself. Forces a new resource
+	// when changed.
+	//
+	// [ocsp-stapling]: https://letsencrypt.org/docs/integration-guide/#implement-ocsp-stapling
+	//
+	// > OCSP stapling requires specific webserver configuration to support the
+	// downloading of the staple from the CA's OCSP endpoints, and should be configured
+	// to tolerate prolonged outages of the OCSP service. Consider this when using
+	// `mustStaple`, and only enable it if you are sure your webserver or service
+	// provider can be configured correctly.
+	MustStaple pulumi.BoolPtrOutput `pulumi:"mustStaple"`
+	// Insert a delay after _every_ DNS challenge
+	// record to allow for extra time for DNS propagation before the certificate is
+	// requested. Use this option if you observe issues with requesting certificates
+	// even when DNS challenge records get added successfully. Units are in seconds.
+	// Defaults to 0 (no delay).
+	//
+	// > Be careful with `preCheckDelay` since the delay is executed _per-domain_.
+	// Take your expected delay and divide it by the number of domains you have
+	// configured (`commonName` + `subjectAlternativeNames`).
+	PreCheckDelay pulumi.IntPtrOutput `pulumi:"preCheckDelay"`
+	// The common name of the root of a preferred
+	// alternate certificate chain offered by the CA. The certificates in
+	// `issuerPem` will reflect the chain requested, if available, otherwise the
+	// default chain will be provided. Forces a new resource when changed.
+	//
+	// > `preferredChain` can be used to request alternate chains on Let's Encrypt
+	// during the transition away from their old cross-signed intermediates. See [this
+	// article for more
+	// details](https://letsencrypt.org/2020/12/21/extending-android-compatibility.html).
+	// In their example titled **"What about the alternate chain?"**, the root you
+	// would put in to the `preferredChain` field would be `ISRG Root X1`. The
+	// equivalent in the [staging
+	// environment](https://letsencrypt.org/docs/staging-environment/) is `(STAGING)
+	// Pretend Pear X1`.
+	PreferredChain pulumi.StringPtrOutput `pulumi:"preferredChain"`
+	// The certificate's private key, in PEM format, if the
+	// certificate was generated from scratch and not with
+	// `certificateRequestPem`.  If
+	// `certificateRequestPem` was used, this will be blank.
+	PrivateKeyPem pulumi.StringOutput `pulumi:"privateKeyPem"`
+	// The recursive nameservers that will be
+	// used to check for propagation of DNS challenge records. Defaults to your
+	// system-configured DNS resolvers.
+	RecursiveNameservers pulumi.StringArrayOutput `pulumi:"recursiveNameservers"`
+	// Enables revocation of a certificate upon destroy,
+	// which includes when a resource is re-created. Default is `true`.
+	RevokeCertificateOnDestroy pulumi.BoolPtrOutput `pulumi:"revokeCertificateOnDestroy"`
+	// The certificate's subject alternative names,
+	// domains that this certificate will also be recognized for. Only valid when not
+	// specifying a CSR. Forces a new resource when changed.
+	SubjectAlternativeNames pulumi.StringArrayOutput `pulumi:"subjectAlternativeNames"`
+	// Defines a TLS challenge to use in fulfilling the
+	// request.
+	//
+	// > Only one of `httpChallenge`, `httpWebrootChallenge`, and
+	// `httpMemcachedChallenge` can be defined at once. See the section on Using
+	// HTTP and TLS challenges for more details on
+	// using these and `tlsChallenge`.
+	TlsChallenge CertificateTlsChallengePtrOutput `pulumi:"tlsChallenge"`
 }
 
 // NewCertificate registers a new resource with the given unique name, arguments, and options.
@@ -89,59 +198,277 @@ func GetCertificate(ctx *pulumi.Context,
 
 // Input properties used for looking up and filtering Certificate resources.
 type certificateState struct {
-	AccountKeyPem              *string                            `pulumi:"accountKeyPem"`
-	CertificateDomain          *string                            `pulumi:"certificateDomain"`
-	CertificateNotAfter        *string                            `pulumi:"certificateNotAfter"`
-	CertificateP12             *string                            `pulumi:"certificateP12"`
-	CertificateP12Password     *string                            `pulumi:"certificateP12Password"`
-	CertificatePem             *string                            `pulumi:"certificatePem"`
-	CertificateRequestPem      *string                            `pulumi:"certificateRequestPem"`
-	CertificateUrl             *string                            `pulumi:"certificateUrl"`
-	CommonName                 *string                            `pulumi:"commonName"`
-	DisableCompletePropagation *bool                              `pulumi:"disableCompletePropagation"`
-	DnsChallenges              []CertificateDnsChallenge          `pulumi:"dnsChallenges"`
-	HttpChallenge              *CertificateHttpChallenge          `pulumi:"httpChallenge"`
-	HttpMemcachedChallenge     *CertificateHttpMemcachedChallenge `pulumi:"httpMemcachedChallenge"`
-	HttpWebrootChallenge       *CertificateHttpWebrootChallenge   `pulumi:"httpWebrootChallenge"`
-	IssuerPem                  *string                            `pulumi:"issuerPem"`
-	KeyType                    *string                            `pulumi:"keyType"`
-	MinDaysRemaining           *int                               `pulumi:"minDaysRemaining"`
-	MustStaple                 *bool                              `pulumi:"mustStaple"`
-	PreCheckDelay              *int                               `pulumi:"preCheckDelay"`
-	PreferredChain             *string                            `pulumi:"preferredChain"`
-	PrivateKeyPem              *string                            `pulumi:"privateKeyPem"`
-	RecursiveNameservers       []string                           `pulumi:"recursiveNameservers"`
-	RevokeCertificateOnDestroy *bool                              `pulumi:"revokeCertificateOnDestroy"`
-	SubjectAlternativeNames    []string                           `pulumi:"subjectAlternativeNames"`
-	TlsChallenge               *CertificateTlsChallenge           `pulumi:"tlsChallenge"`
+	// The private key of the account that is
+	// requesting the certificate. Forces a new resource when changed.
+	AccountKeyPem *string `pulumi:"accountKeyPem"`
+	// The common name of the certificate.
+	CertificateDomain *string `pulumi:"certificateDomain"`
+	// The expiry date of the certificate, laid out in
+	// RFC3339 format (`2006-01-02T15:04:05Z07:00`).
+	CertificateNotAfter *string `pulumi:"certificateNotAfter"`
+	// The certificate, any intermediates, and the private key
+	// archived as a PFX file (PKCS12 format, generally used by Microsoft products).
+	// The data is base64 encoded (including padding), and its password is
+	// configurable via the `certificateP12Password`
+	// argument. This field is empty if creating a certificate from a CSR.
+	CertificateP12 *string `pulumi:"certificateP12"`
+	// Password to be used when generating
+	// the PFX file stored in `certificateP12`. Defaults to an
+	// empty string.
+	CertificateP12Password *string `pulumi:"certificateP12Password"`
+	// The certificate in PEM format. This does not include the
+	// `issuerPem`. This certificate can be concatenated with `issuerPem` to form
+	// a full chain, e.g. `"${acme_certificate.certificate.certificate_pem}${acme_certificate.certificate.issuer_pem}"`
+	CertificatePem *string `pulumi:"certificatePem"`
+	// A pre-created certificate request, such as one
+	// from [`tlsCertRequest`][tls-cert-request], or one from an external source,
+	// in PEM format.  Either this, or the in-resource request options
+	// (`commonName`, `keyType`, and optionally `subjectAlternativeNames`) need
+	// to be specified. Forces a new resource when changed.
+	CertificateRequestPem *string `pulumi:"certificateRequestPem"`
+	// The full URL of the certificate within the ACME CA.
+	CertificateUrl *string `pulumi:"certificateUrl"`
+	// The certificate's common name, the primary domain that the
+	// certificate will be recognized for. Required when not specifying a CSR. Forces
+	// a new resource when changed.
+	CommonName *string `pulumi:"commonName"`
+	// Disable the requirement for full
+	// propagation of the TXT challenge records before proceeding with validation.
+	// Defaults to `false`.
+	//
+	// > See About DNS propagation checks for details
+	// on the `recursiveNameservers` and `disableCompletePropagation` settings.
+	DisableCompletePropagation *bool `pulumi:"disableCompletePropagation"`
+	// The DNS challenges to
+	// use in fulfilling the request.
+	DnsChallenges []CertificateDnsChallenge `pulumi:"dnsChallenges"`
+	// Defines an HTTP challenge to use in fulfilling
+	// the request.
+	HttpChallenge *CertificateHttpChallenge `pulumi:"httpChallenge"`
+	// Defines an alternate type of HTTP
+	// challenge that can be used to serve up challenges to a
+	// [Memcached](https://memcached.org/) cluster.
+	HttpMemcachedChallenge *CertificateHttpMemcachedChallenge `pulumi:"httpMemcachedChallenge"`
+	// Defines an alternate type of HTTP
+	// challenge that can be used to place a file at a location that can be served by
+	// an out-of-band webserver.
+	HttpWebrootChallenge *CertificateHttpWebrootChallenge `pulumi:"httpWebrootChallenge"`
+	// The intermediate certificates of the issuer. Multiple
+	// certificates are concatenated in this field when there is more than one
+	// intermediate certificate in the chain.
+	IssuerPem *string `pulumi:"issuerPem"`
+	// The key type for the certificate's private key. Can be one of:
+	// `P256` and `P384` (for ECDSA keys of respective length) or `2048`, `4096`, and
+	// `8192` (for RSA keys of respective length). Required when not specifying a
+	// CSR. The default is `2048` (RSA key of 2048 bits). Forces a new resource when
+	// changed.
+	KeyType *string `pulumi:"keyType"`
+	// The minimum amount of days remaining on the
+	// expiration of a certificate before a renewal is attempted. The default is
+	// `30`. A value of less than `0` means that the certificate will never be
+	// renewed.
+	MinDaysRemaining *int `pulumi:"minDaysRemaining"`
+	// Enables the [OCSP Stapling Required][ocsp-stapling]
+	// TLS Security Policy extension. Certificates with this extension must include a
+	// valid OCSP Staple in the TLS handshake for the connection to succeed.
+	// Defaults to `false`. Note that this option has no effect when using an
+	// external CSR - it must be enabled in the CSR itself. Forces a new resource
+	// when changed.
+	//
+	// [ocsp-stapling]: https://letsencrypt.org/docs/integration-guide/#implement-ocsp-stapling
+	//
+	// > OCSP stapling requires specific webserver configuration to support the
+	// downloading of the staple from the CA's OCSP endpoints, and should be configured
+	// to tolerate prolonged outages of the OCSP service. Consider this when using
+	// `mustStaple`, and only enable it if you are sure your webserver or service
+	// provider can be configured correctly.
+	MustStaple *bool `pulumi:"mustStaple"`
+	// Insert a delay after _every_ DNS challenge
+	// record to allow for extra time for DNS propagation before the certificate is
+	// requested. Use this option if you observe issues with requesting certificates
+	// even when DNS challenge records get added successfully. Units are in seconds.
+	// Defaults to 0 (no delay).
+	//
+	// > Be careful with `preCheckDelay` since the delay is executed _per-domain_.
+	// Take your expected delay and divide it by the number of domains you have
+	// configured (`commonName` + `subjectAlternativeNames`).
+	PreCheckDelay *int `pulumi:"preCheckDelay"`
+	// The common name of the root of a preferred
+	// alternate certificate chain offered by the CA. The certificates in
+	// `issuerPem` will reflect the chain requested, if available, otherwise the
+	// default chain will be provided. Forces a new resource when changed.
+	//
+	// > `preferredChain` can be used to request alternate chains on Let's Encrypt
+	// during the transition away from their old cross-signed intermediates. See [this
+	// article for more
+	// details](https://letsencrypt.org/2020/12/21/extending-android-compatibility.html).
+	// In their example titled **"What about the alternate chain?"**, the root you
+	// would put in to the `preferredChain` field would be `ISRG Root X1`. The
+	// equivalent in the [staging
+	// environment](https://letsencrypt.org/docs/staging-environment/) is `(STAGING)
+	// Pretend Pear X1`.
+	PreferredChain *string `pulumi:"preferredChain"`
+	// The certificate's private key, in PEM format, if the
+	// certificate was generated from scratch and not with
+	// `certificateRequestPem`.  If
+	// `certificateRequestPem` was used, this will be blank.
+	PrivateKeyPem *string `pulumi:"privateKeyPem"`
+	// The recursive nameservers that will be
+	// used to check for propagation of DNS challenge records. Defaults to your
+	// system-configured DNS resolvers.
+	RecursiveNameservers []string `pulumi:"recursiveNameservers"`
+	// Enables revocation of a certificate upon destroy,
+	// which includes when a resource is re-created. Default is `true`.
+	RevokeCertificateOnDestroy *bool `pulumi:"revokeCertificateOnDestroy"`
+	// The certificate's subject alternative names,
+	// domains that this certificate will also be recognized for. Only valid when not
+	// specifying a CSR. Forces a new resource when changed.
+	SubjectAlternativeNames []string `pulumi:"subjectAlternativeNames"`
+	// Defines a TLS challenge to use in fulfilling the
+	// request.
+	//
+	// > Only one of `httpChallenge`, `httpWebrootChallenge`, and
+	// `httpMemcachedChallenge` can be defined at once. See the section on Using
+	// HTTP and TLS challenges for more details on
+	// using these and `tlsChallenge`.
+	TlsChallenge *CertificateTlsChallenge `pulumi:"tlsChallenge"`
 }
 
 type CertificateState struct {
-	AccountKeyPem              pulumi.StringPtrInput
-	CertificateDomain          pulumi.StringPtrInput
-	CertificateNotAfter        pulumi.StringPtrInput
-	CertificateP12             pulumi.StringPtrInput
-	CertificateP12Password     pulumi.StringPtrInput
-	CertificatePem             pulumi.StringPtrInput
-	CertificateRequestPem      pulumi.StringPtrInput
-	CertificateUrl             pulumi.StringPtrInput
-	CommonName                 pulumi.StringPtrInput
+	// The private key of the account that is
+	// requesting the certificate. Forces a new resource when changed.
+	AccountKeyPem pulumi.StringPtrInput
+	// The common name of the certificate.
+	CertificateDomain pulumi.StringPtrInput
+	// The expiry date of the certificate, laid out in
+	// RFC3339 format (`2006-01-02T15:04:05Z07:00`).
+	CertificateNotAfter pulumi.StringPtrInput
+	// The certificate, any intermediates, and the private key
+	// archived as a PFX file (PKCS12 format, generally used by Microsoft products).
+	// The data is base64 encoded (including padding), and its password is
+	// configurable via the `certificateP12Password`
+	// argument. This field is empty if creating a certificate from a CSR.
+	CertificateP12 pulumi.StringPtrInput
+	// Password to be used when generating
+	// the PFX file stored in `certificateP12`. Defaults to an
+	// empty string.
+	CertificateP12Password pulumi.StringPtrInput
+	// The certificate in PEM format. This does not include the
+	// `issuerPem`. This certificate can be concatenated with `issuerPem` to form
+	// a full chain, e.g. `"${acme_certificate.certificate.certificate_pem}${acme_certificate.certificate.issuer_pem}"`
+	CertificatePem pulumi.StringPtrInput
+	// A pre-created certificate request, such as one
+	// from [`tlsCertRequest`][tls-cert-request], or one from an external source,
+	// in PEM format.  Either this, or the in-resource request options
+	// (`commonName`, `keyType`, and optionally `subjectAlternativeNames`) need
+	// to be specified. Forces a new resource when changed.
+	CertificateRequestPem pulumi.StringPtrInput
+	// The full URL of the certificate within the ACME CA.
+	CertificateUrl pulumi.StringPtrInput
+	// The certificate's common name, the primary domain that the
+	// certificate will be recognized for. Required when not specifying a CSR. Forces
+	// a new resource when changed.
+	CommonName pulumi.StringPtrInput
+	// Disable the requirement for full
+	// propagation of the TXT challenge records before proceeding with validation.
+	// Defaults to `false`.
+	//
+	// > See About DNS propagation checks for details
+	// on the `recursiveNameservers` and `disableCompletePropagation` settings.
 	DisableCompletePropagation pulumi.BoolPtrInput
-	DnsChallenges              CertificateDnsChallengeArrayInput
-	HttpChallenge              CertificateHttpChallengePtrInput
-	HttpMemcachedChallenge     CertificateHttpMemcachedChallengePtrInput
-	HttpWebrootChallenge       CertificateHttpWebrootChallengePtrInput
-	IssuerPem                  pulumi.StringPtrInput
-	KeyType                    pulumi.StringPtrInput
-	MinDaysRemaining           pulumi.IntPtrInput
-	MustStaple                 pulumi.BoolPtrInput
-	PreCheckDelay              pulumi.IntPtrInput
-	PreferredChain             pulumi.StringPtrInput
-	PrivateKeyPem              pulumi.StringPtrInput
-	RecursiveNameservers       pulumi.StringArrayInput
+	// The DNS challenges to
+	// use in fulfilling the request.
+	DnsChallenges CertificateDnsChallengeArrayInput
+	// Defines an HTTP challenge to use in fulfilling
+	// the request.
+	HttpChallenge CertificateHttpChallengePtrInput
+	// Defines an alternate type of HTTP
+	// challenge that can be used to serve up challenges to a
+	// [Memcached](https://memcached.org/) cluster.
+	HttpMemcachedChallenge CertificateHttpMemcachedChallengePtrInput
+	// Defines an alternate type of HTTP
+	// challenge that can be used to place a file at a location that can be served by
+	// an out-of-band webserver.
+	HttpWebrootChallenge CertificateHttpWebrootChallengePtrInput
+	// The intermediate certificates of the issuer. Multiple
+	// certificates are concatenated in this field when there is more than one
+	// intermediate certificate in the chain.
+	IssuerPem pulumi.StringPtrInput
+	// The key type for the certificate's private key. Can be one of:
+	// `P256` and `P384` (for ECDSA keys of respective length) or `2048`, `4096`, and
+	// `8192` (for RSA keys of respective length). Required when not specifying a
+	// CSR. The default is `2048` (RSA key of 2048 bits). Forces a new resource when
+	// changed.
+	KeyType pulumi.StringPtrInput
+	// The minimum amount of days remaining on the
+	// expiration of a certificate before a renewal is attempted. The default is
+	// `30`. A value of less than `0` means that the certificate will never be
+	// renewed.
+	MinDaysRemaining pulumi.IntPtrInput
+	// Enables the [OCSP Stapling Required][ocsp-stapling]
+	// TLS Security Policy extension. Certificates with this extension must include a
+	// valid OCSP Staple in the TLS handshake for the connection to succeed.
+	// Defaults to `false`. Note that this option has no effect when using an
+	// external CSR - it must be enabled in the CSR itself. Forces a new resource
+	// when changed.
+	//
+	// [ocsp-stapling]: https://letsencrypt.org/docs/integration-guide/#implement-ocsp-stapling
+	//
+	// > OCSP stapling requires specific webserver configuration to support the
+	// downloading of the staple from the CA's OCSP endpoints, and should be configured
+	// to tolerate prolonged outages of the OCSP service. Consider this when using
+	// `mustStaple`, and only enable it if you are sure your webserver or service
+	// provider can be configured correctly.
+	MustStaple pulumi.BoolPtrInput
+	// Insert a delay after _every_ DNS challenge
+	// record to allow for extra time for DNS propagation before the certificate is
+	// requested. Use this option if you observe issues with requesting certificates
+	// even when DNS challenge records get added successfully. Units are in seconds.
+	// Defaults to 0 (no delay).
+	//
+	// > Be careful with `preCheckDelay` since the delay is executed _per-domain_.
+	// Take your expected delay and divide it by the number of domains you have
+	// configured (`commonName` + `subjectAlternativeNames`).
+	PreCheckDelay pulumi.IntPtrInput
+	// The common name of the root of a preferred
+	// alternate certificate chain offered by the CA. The certificates in
+	// `issuerPem` will reflect the chain requested, if available, otherwise the
+	// default chain will be provided. Forces a new resource when changed.
+	//
+	// > `preferredChain` can be used to request alternate chains on Let's Encrypt
+	// during the transition away from their old cross-signed intermediates. See [this
+	// article for more
+	// details](https://letsencrypt.org/2020/12/21/extending-android-compatibility.html).
+	// In their example titled **"What about the alternate chain?"**, the root you
+	// would put in to the `preferredChain` field would be `ISRG Root X1`. The
+	// equivalent in the [staging
+	// environment](https://letsencrypt.org/docs/staging-environment/) is `(STAGING)
+	// Pretend Pear X1`.
+	PreferredChain pulumi.StringPtrInput
+	// The certificate's private key, in PEM format, if the
+	// certificate was generated from scratch and not with
+	// `certificateRequestPem`.  If
+	// `certificateRequestPem` was used, this will be blank.
+	PrivateKeyPem pulumi.StringPtrInput
+	// The recursive nameservers that will be
+	// used to check for propagation of DNS challenge records. Defaults to your
+	// system-configured DNS resolvers.
+	RecursiveNameservers pulumi.StringArrayInput
+	// Enables revocation of a certificate upon destroy,
+	// which includes when a resource is re-created. Default is `true`.
 	RevokeCertificateOnDestroy pulumi.BoolPtrInput
-	SubjectAlternativeNames    pulumi.StringArrayInput
-	TlsChallenge               CertificateTlsChallengePtrInput
+	// The certificate's subject alternative names,
+	// domains that this certificate will also be recognized for. Only valid when not
+	// specifying a CSR. Forces a new resource when changed.
+	SubjectAlternativeNames pulumi.StringArrayInput
+	// Defines a TLS challenge to use in fulfilling the
+	// request.
+	//
+	// > Only one of `httpChallenge`, `httpWebrootChallenge`, and
+	// `httpMemcachedChallenge` can be defined at once. See the section on Using
+	// HTTP and TLS challenges for more details on
+	// using these and `tlsChallenge`.
+	TlsChallenge CertificateTlsChallengePtrInput
 }
 
 func (CertificateState) ElementType() reflect.Type {
@@ -149,46 +476,226 @@ func (CertificateState) ElementType() reflect.Type {
 }
 
 type certificateArgs struct {
-	AccountKeyPem              string                             `pulumi:"accountKeyPem"`
-	CertificateP12Password     *string                            `pulumi:"certificateP12Password"`
-	CertificateRequestPem      *string                            `pulumi:"certificateRequestPem"`
-	CommonName                 *string                            `pulumi:"commonName"`
-	DisableCompletePropagation *bool                              `pulumi:"disableCompletePropagation"`
-	DnsChallenges              []CertificateDnsChallenge          `pulumi:"dnsChallenges"`
-	HttpChallenge              *CertificateHttpChallenge          `pulumi:"httpChallenge"`
-	HttpMemcachedChallenge     *CertificateHttpMemcachedChallenge `pulumi:"httpMemcachedChallenge"`
-	HttpWebrootChallenge       *CertificateHttpWebrootChallenge   `pulumi:"httpWebrootChallenge"`
-	KeyType                    *string                            `pulumi:"keyType"`
-	MinDaysRemaining           *int                               `pulumi:"minDaysRemaining"`
-	MustStaple                 *bool                              `pulumi:"mustStaple"`
-	PreCheckDelay              *int                               `pulumi:"preCheckDelay"`
-	PreferredChain             *string                            `pulumi:"preferredChain"`
-	RecursiveNameservers       []string                           `pulumi:"recursiveNameservers"`
-	RevokeCertificateOnDestroy *bool                              `pulumi:"revokeCertificateOnDestroy"`
-	SubjectAlternativeNames    []string                           `pulumi:"subjectAlternativeNames"`
-	TlsChallenge               *CertificateTlsChallenge           `pulumi:"tlsChallenge"`
+	// The private key of the account that is
+	// requesting the certificate. Forces a new resource when changed.
+	AccountKeyPem string `pulumi:"accountKeyPem"`
+	// Password to be used when generating
+	// the PFX file stored in `certificateP12`. Defaults to an
+	// empty string.
+	CertificateP12Password *string `pulumi:"certificateP12Password"`
+	// A pre-created certificate request, such as one
+	// from [`tlsCertRequest`][tls-cert-request], or one from an external source,
+	// in PEM format.  Either this, or the in-resource request options
+	// (`commonName`, `keyType`, and optionally `subjectAlternativeNames`) need
+	// to be specified. Forces a new resource when changed.
+	CertificateRequestPem *string `pulumi:"certificateRequestPem"`
+	// The certificate's common name, the primary domain that the
+	// certificate will be recognized for. Required when not specifying a CSR. Forces
+	// a new resource when changed.
+	CommonName *string `pulumi:"commonName"`
+	// Disable the requirement for full
+	// propagation of the TXT challenge records before proceeding with validation.
+	// Defaults to `false`.
+	//
+	// > See About DNS propagation checks for details
+	// on the `recursiveNameservers` and `disableCompletePropagation` settings.
+	DisableCompletePropagation *bool `pulumi:"disableCompletePropagation"`
+	// The DNS challenges to
+	// use in fulfilling the request.
+	DnsChallenges []CertificateDnsChallenge `pulumi:"dnsChallenges"`
+	// Defines an HTTP challenge to use in fulfilling
+	// the request.
+	HttpChallenge *CertificateHttpChallenge `pulumi:"httpChallenge"`
+	// Defines an alternate type of HTTP
+	// challenge that can be used to serve up challenges to a
+	// [Memcached](https://memcached.org/) cluster.
+	HttpMemcachedChallenge *CertificateHttpMemcachedChallenge `pulumi:"httpMemcachedChallenge"`
+	// Defines an alternate type of HTTP
+	// challenge that can be used to place a file at a location that can be served by
+	// an out-of-band webserver.
+	HttpWebrootChallenge *CertificateHttpWebrootChallenge `pulumi:"httpWebrootChallenge"`
+	// The key type for the certificate's private key. Can be one of:
+	// `P256` and `P384` (for ECDSA keys of respective length) or `2048`, `4096`, and
+	// `8192` (for RSA keys of respective length). Required when not specifying a
+	// CSR. The default is `2048` (RSA key of 2048 bits). Forces a new resource when
+	// changed.
+	KeyType *string `pulumi:"keyType"`
+	// The minimum amount of days remaining on the
+	// expiration of a certificate before a renewal is attempted. The default is
+	// `30`. A value of less than `0` means that the certificate will never be
+	// renewed.
+	MinDaysRemaining *int `pulumi:"minDaysRemaining"`
+	// Enables the [OCSP Stapling Required][ocsp-stapling]
+	// TLS Security Policy extension. Certificates with this extension must include a
+	// valid OCSP Staple in the TLS handshake for the connection to succeed.
+	// Defaults to `false`. Note that this option has no effect when using an
+	// external CSR - it must be enabled in the CSR itself. Forces a new resource
+	// when changed.
+	//
+	// [ocsp-stapling]: https://letsencrypt.org/docs/integration-guide/#implement-ocsp-stapling
+	//
+	// > OCSP stapling requires specific webserver configuration to support the
+	// downloading of the staple from the CA's OCSP endpoints, and should be configured
+	// to tolerate prolonged outages of the OCSP service. Consider this when using
+	// `mustStaple`, and only enable it if you are sure your webserver or service
+	// provider can be configured correctly.
+	MustStaple *bool `pulumi:"mustStaple"`
+	// Insert a delay after _every_ DNS challenge
+	// record to allow for extra time for DNS propagation before the certificate is
+	// requested. Use this option if you observe issues with requesting certificates
+	// even when DNS challenge records get added successfully. Units are in seconds.
+	// Defaults to 0 (no delay).
+	//
+	// > Be careful with `preCheckDelay` since the delay is executed _per-domain_.
+	// Take your expected delay and divide it by the number of domains you have
+	// configured (`commonName` + `subjectAlternativeNames`).
+	PreCheckDelay *int `pulumi:"preCheckDelay"`
+	// The common name of the root of a preferred
+	// alternate certificate chain offered by the CA. The certificates in
+	// `issuerPem` will reflect the chain requested, if available, otherwise the
+	// default chain will be provided. Forces a new resource when changed.
+	//
+	// > `preferredChain` can be used to request alternate chains on Let's Encrypt
+	// during the transition away from their old cross-signed intermediates. See [this
+	// article for more
+	// details](https://letsencrypt.org/2020/12/21/extending-android-compatibility.html).
+	// In their example titled **"What about the alternate chain?"**, the root you
+	// would put in to the `preferredChain` field would be `ISRG Root X1`. The
+	// equivalent in the [staging
+	// environment](https://letsencrypt.org/docs/staging-environment/) is `(STAGING)
+	// Pretend Pear X1`.
+	PreferredChain *string `pulumi:"preferredChain"`
+	// The recursive nameservers that will be
+	// used to check for propagation of DNS challenge records. Defaults to your
+	// system-configured DNS resolvers.
+	RecursiveNameservers []string `pulumi:"recursiveNameservers"`
+	// Enables revocation of a certificate upon destroy,
+	// which includes when a resource is re-created. Default is `true`.
+	RevokeCertificateOnDestroy *bool `pulumi:"revokeCertificateOnDestroy"`
+	// The certificate's subject alternative names,
+	// domains that this certificate will also be recognized for. Only valid when not
+	// specifying a CSR. Forces a new resource when changed.
+	SubjectAlternativeNames []string `pulumi:"subjectAlternativeNames"`
+	// Defines a TLS challenge to use in fulfilling the
+	// request.
+	//
+	// > Only one of `httpChallenge`, `httpWebrootChallenge`, and
+	// `httpMemcachedChallenge` can be defined at once. See the section on Using
+	// HTTP and TLS challenges for more details on
+	// using these and `tlsChallenge`.
+	TlsChallenge *CertificateTlsChallenge `pulumi:"tlsChallenge"`
 }
 
 // The set of arguments for constructing a Certificate resource.
 type CertificateArgs struct {
-	AccountKeyPem              pulumi.StringInput
-	CertificateP12Password     pulumi.StringPtrInput
-	CertificateRequestPem      pulumi.StringPtrInput
-	CommonName                 pulumi.StringPtrInput
+	// The private key of the account that is
+	// requesting the certificate. Forces a new resource when changed.
+	AccountKeyPem pulumi.StringInput
+	// Password to be used when generating
+	// the PFX file stored in `certificateP12`. Defaults to an
+	// empty string.
+	CertificateP12Password pulumi.StringPtrInput
+	// A pre-created certificate request, such as one
+	// from [`tlsCertRequest`][tls-cert-request], or one from an external source,
+	// in PEM format.  Either this, or the in-resource request options
+	// (`commonName`, `keyType`, and optionally `subjectAlternativeNames`) need
+	// to be specified. Forces a new resource when changed.
+	CertificateRequestPem pulumi.StringPtrInput
+	// The certificate's common name, the primary domain that the
+	// certificate will be recognized for. Required when not specifying a CSR. Forces
+	// a new resource when changed.
+	CommonName pulumi.StringPtrInput
+	// Disable the requirement for full
+	// propagation of the TXT challenge records before proceeding with validation.
+	// Defaults to `false`.
+	//
+	// > See About DNS propagation checks for details
+	// on the `recursiveNameservers` and `disableCompletePropagation` settings.
 	DisableCompletePropagation pulumi.BoolPtrInput
-	DnsChallenges              CertificateDnsChallengeArrayInput
-	HttpChallenge              CertificateHttpChallengePtrInput
-	HttpMemcachedChallenge     CertificateHttpMemcachedChallengePtrInput
-	HttpWebrootChallenge       CertificateHttpWebrootChallengePtrInput
-	KeyType                    pulumi.StringPtrInput
-	MinDaysRemaining           pulumi.IntPtrInput
-	MustStaple                 pulumi.BoolPtrInput
-	PreCheckDelay              pulumi.IntPtrInput
-	PreferredChain             pulumi.StringPtrInput
-	RecursiveNameservers       pulumi.StringArrayInput
+	// The DNS challenges to
+	// use in fulfilling the request.
+	DnsChallenges CertificateDnsChallengeArrayInput
+	// Defines an HTTP challenge to use in fulfilling
+	// the request.
+	HttpChallenge CertificateHttpChallengePtrInput
+	// Defines an alternate type of HTTP
+	// challenge that can be used to serve up challenges to a
+	// [Memcached](https://memcached.org/) cluster.
+	HttpMemcachedChallenge CertificateHttpMemcachedChallengePtrInput
+	// Defines an alternate type of HTTP
+	// challenge that can be used to place a file at a location that can be served by
+	// an out-of-band webserver.
+	HttpWebrootChallenge CertificateHttpWebrootChallengePtrInput
+	// The key type for the certificate's private key. Can be one of:
+	// `P256` and `P384` (for ECDSA keys of respective length) or `2048`, `4096`, and
+	// `8192` (for RSA keys of respective length). Required when not specifying a
+	// CSR. The default is `2048` (RSA key of 2048 bits). Forces a new resource when
+	// changed.
+	KeyType pulumi.StringPtrInput
+	// The minimum amount of days remaining on the
+	// expiration of a certificate before a renewal is attempted. The default is
+	// `30`. A value of less than `0` means that the certificate will never be
+	// renewed.
+	MinDaysRemaining pulumi.IntPtrInput
+	// Enables the [OCSP Stapling Required][ocsp-stapling]
+	// TLS Security Policy extension. Certificates with this extension must include a
+	// valid OCSP Staple in the TLS handshake for the connection to succeed.
+	// Defaults to `false`. Note that this option has no effect when using an
+	// external CSR - it must be enabled in the CSR itself. Forces a new resource
+	// when changed.
+	//
+	// [ocsp-stapling]: https://letsencrypt.org/docs/integration-guide/#implement-ocsp-stapling
+	//
+	// > OCSP stapling requires specific webserver configuration to support the
+	// downloading of the staple from the CA's OCSP endpoints, and should be configured
+	// to tolerate prolonged outages of the OCSP service. Consider this when using
+	// `mustStaple`, and only enable it if you are sure your webserver or service
+	// provider can be configured correctly.
+	MustStaple pulumi.BoolPtrInput
+	// Insert a delay after _every_ DNS challenge
+	// record to allow for extra time for DNS propagation before the certificate is
+	// requested. Use this option if you observe issues with requesting certificates
+	// even when DNS challenge records get added successfully. Units are in seconds.
+	// Defaults to 0 (no delay).
+	//
+	// > Be careful with `preCheckDelay` since the delay is executed _per-domain_.
+	// Take your expected delay and divide it by the number of domains you have
+	// configured (`commonName` + `subjectAlternativeNames`).
+	PreCheckDelay pulumi.IntPtrInput
+	// The common name of the root of a preferred
+	// alternate certificate chain offered by the CA. The certificates in
+	// `issuerPem` will reflect the chain requested, if available, otherwise the
+	// default chain will be provided. Forces a new resource when changed.
+	//
+	// > `preferredChain` can be used to request alternate chains on Let's Encrypt
+	// during the transition away from their old cross-signed intermediates. See [this
+	// article for more
+	// details](https://letsencrypt.org/2020/12/21/extending-android-compatibility.html).
+	// In their example titled **"What about the alternate chain?"**, the root you
+	// would put in to the `preferredChain` field would be `ISRG Root X1`. The
+	// equivalent in the [staging
+	// environment](https://letsencrypt.org/docs/staging-environment/) is `(STAGING)
+	// Pretend Pear X1`.
+	PreferredChain pulumi.StringPtrInput
+	// The recursive nameservers that will be
+	// used to check for propagation of DNS challenge records. Defaults to your
+	// system-configured DNS resolvers.
+	RecursiveNameservers pulumi.StringArrayInput
+	// Enables revocation of a certificate upon destroy,
+	// which includes when a resource is re-created. Default is `true`.
 	RevokeCertificateOnDestroy pulumi.BoolPtrInput
-	SubjectAlternativeNames    pulumi.StringArrayInput
-	TlsChallenge               CertificateTlsChallengePtrInput
+	// The certificate's subject alternative names,
+	// domains that this certificate will also be recognized for. Only valid when not
+	// specifying a CSR. Forces a new resource when changed.
+	SubjectAlternativeNames pulumi.StringArrayInput
+	// Defines a TLS challenge to use in fulfilling the
+	// request.
+	//
+	// > Only one of `httpChallenge`, `httpWebrootChallenge`, and
+	// `httpMemcachedChallenge` can be defined at once. See the section on Using
+	// HTTP and TLS challenges for more details on
+	// using these and `tlsChallenge`.
+	TlsChallenge CertificateTlsChallengePtrInput
 }
 
 func (CertificateArgs) ElementType() reflect.Type {
@@ -302,102 +809,211 @@ func (o CertificateOutput) ToOutput(ctx context.Context) pulumix.Output[*Certifi
 	}
 }
 
+// The private key of the account that is
+// requesting the certificate. Forces a new resource when changed.
 func (o CertificateOutput) AccountKeyPem() pulumi.StringOutput {
 	return o.ApplyT(func(v *Certificate) pulumi.StringOutput { return v.AccountKeyPem }).(pulumi.StringOutput)
 }
 
+// The common name of the certificate.
 func (o CertificateOutput) CertificateDomain() pulumi.StringOutput {
 	return o.ApplyT(func(v *Certificate) pulumi.StringOutput { return v.CertificateDomain }).(pulumi.StringOutput)
 }
 
+// The expiry date of the certificate, laid out in
+// RFC3339 format (`2006-01-02T15:04:05Z07:00`).
 func (o CertificateOutput) CertificateNotAfter() pulumi.StringOutput {
 	return o.ApplyT(func(v *Certificate) pulumi.StringOutput { return v.CertificateNotAfter }).(pulumi.StringOutput)
 }
 
+// The certificate, any intermediates, and the private key
+// archived as a PFX file (PKCS12 format, generally used by Microsoft products).
+// The data is base64 encoded (including padding), and its password is
+// configurable via the `certificateP12Password`
+// argument. This field is empty if creating a certificate from a CSR.
 func (o CertificateOutput) CertificateP12() pulumi.StringOutput {
 	return o.ApplyT(func(v *Certificate) pulumi.StringOutput { return v.CertificateP12 }).(pulumi.StringOutput)
 }
 
+// Password to be used when generating
+// the PFX file stored in `certificateP12`. Defaults to an
+// empty string.
 func (o CertificateOutput) CertificateP12Password() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *Certificate) pulumi.StringPtrOutput { return v.CertificateP12Password }).(pulumi.StringPtrOutput)
 }
 
+// The certificate in PEM format. This does not include the
+// `issuerPem`. This certificate can be concatenated with `issuerPem` to form
+// a full chain, e.g. `"${acme_certificate.certificate.certificate_pem}${acme_certificate.certificate.issuer_pem}"`
 func (o CertificateOutput) CertificatePem() pulumi.StringOutput {
 	return o.ApplyT(func(v *Certificate) pulumi.StringOutput { return v.CertificatePem }).(pulumi.StringOutput)
 }
 
+// A pre-created certificate request, such as one
+// from [`tlsCertRequest`][tls-cert-request], or one from an external source,
+// in PEM format.  Either this, or the in-resource request options
+// (`commonName`, `keyType`, and optionally `subjectAlternativeNames`) need
+// to be specified. Forces a new resource when changed.
 func (o CertificateOutput) CertificateRequestPem() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *Certificate) pulumi.StringPtrOutput { return v.CertificateRequestPem }).(pulumi.StringPtrOutput)
 }
 
+// The full URL of the certificate within the ACME CA.
 func (o CertificateOutput) CertificateUrl() pulumi.StringOutput {
 	return o.ApplyT(func(v *Certificate) pulumi.StringOutput { return v.CertificateUrl }).(pulumi.StringOutput)
 }
 
+// The certificate's common name, the primary domain that the
+// certificate will be recognized for. Required when not specifying a CSR. Forces
+// a new resource when changed.
 func (o CertificateOutput) CommonName() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *Certificate) pulumi.StringPtrOutput { return v.CommonName }).(pulumi.StringPtrOutput)
 }
 
+// Disable the requirement for full
+// propagation of the TXT challenge records before proceeding with validation.
+// Defaults to `false`.
+//
+// > See About DNS propagation checks for details
+// on the `recursiveNameservers` and `disableCompletePropagation` settings.
 func (o CertificateOutput) DisableCompletePropagation() pulumi.BoolPtrOutput {
 	return o.ApplyT(func(v *Certificate) pulumi.BoolPtrOutput { return v.DisableCompletePropagation }).(pulumi.BoolPtrOutput)
 }
 
+// The DNS challenges to
+// use in fulfilling the request.
 func (o CertificateOutput) DnsChallenges() CertificateDnsChallengeArrayOutput {
 	return o.ApplyT(func(v *Certificate) CertificateDnsChallengeArrayOutput { return v.DnsChallenges }).(CertificateDnsChallengeArrayOutput)
 }
 
+// Defines an HTTP challenge to use in fulfilling
+// the request.
 func (o CertificateOutput) HttpChallenge() CertificateHttpChallengePtrOutput {
 	return o.ApplyT(func(v *Certificate) CertificateHttpChallengePtrOutput { return v.HttpChallenge }).(CertificateHttpChallengePtrOutput)
 }
 
+// Defines an alternate type of HTTP
+// challenge that can be used to serve up challenges to a
+// [Memcached](https://memcached.org/) cluster.
 func (o CertificateOutput) HttpMemcachedChallenge() CertificateHttpMemcachedChallengePtrOutput {
 	return o.ApplyT(func(v *Certificate) CertificateHttpMemcachedChallengePtrOutput { return v.HttpMemcachedChallenge }).(CertificateHttpMemcachedChallengePtrOutput)
 }
 
+// Defines an alternate type of HTTP
+// challenge that can be used to place a file at a location that can be served by
+// an out-of-band webserver.
 func (o CertificateOutput) HttpWebrootChallenge() CertificateHttpWebrootChallengePtrOutput {
 	return o.ApplyT(func(v *Certificate) CertificateHttpWebrootChallengePtrOutput { return v.HttpWebrootChallenge }).(CertificateHttpWebrootChallengePtrOutput)
 }
 
+// The intermediate certificates of the issuer. Multiple
+// certificates are concatenated in this field when there is more than one
+// intermediate certificate in the chain.
 func (o CertificateOutput) IssuerPem() pulumi.StringOutput {
 	return o.ApplyT(func(v *Certificate) pulumi.StringOutput { return v.IssuerPem }).(pulumi.StringOutput)
 }
 
+// The key type for the certificate's private key. Can be one of:
+// `P256` and `P384` (for ECDSA keys of respective length) or `2048`, `4096`, and
+// `8192` (for RSA keys of respective length). Required when not specifying a
+// CSR. The default is `2048` (RSA key of 2048 bits). Forces a new resource when
+// changed.
 func (o CertificateOutput) KeyType() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *Certificate) pulumi.StringPtrOutput { return v.KeyType }).(pulumi.StringPtrOutput)
 }
 
+// The minimum amount of days remaining on the
+// expiration of a certificate before a renewal is attempted. The default is
+// `30`. A value of less than `0` means that the certificate will never be
+// renewed.
 func (o CertificateOutput) MinDaysRemaining() pulumi.IntPtrOutput {
 	return o.ApplyT(func(v *Certificate) pulumi.IntPtrOutput { return v.MinDaysRemaining }).(pulumi.IntPtrOutput)
 }
 
+// Enables the [OCSP Stapling Required][ocsp-stapling]
+// TLS Security Policy extension. Certificates with this extension must include a
+// valid OCSP Staple in the TLS handshake for the connection to succeed.
+// Defaults to `false`. Note that this option has no effect when using an
+// external CSR - it must be enabled in the CSR itself. Forces a new resource
+// when changed.
+//
+// > OCSP stapling requires specific webserver configuration to support the
+// downloading of the staple from the CA's OCSP endpoints, and should be configured
+// to tolerate prolonged outages of the OCSP service. Consider this when using
+// `mustStaple`, and only enable it if you are sure your webserver or service
+// provider can be configured correctly.
+//
+// [ocsp-stapling]: https://letsencrypt.org/docs/integration-guide/#implement-ocsp-stapling
 func (o CertificateOutput) MustStaple() pulumi.BoolPtrOutput {
 	return o.ApplyT(func(v *Certificate) pulumi.BoolPtrOutput { return v.MustStaple }).(pulumi.BoolPtrOutput)
 }
 
+// Insert a delay after _every_ DNS challenge
+// record to allow for extra time for DNS propagation before the certificate is
+// requested. Use this option if you observe issues with requesting certificates
+// even when DNS challenge records get added successfully. Units are in seconds.
+// Defaults to 0 (no delay).
+//
+// > Be careful with `preCheckDelay` since the delay is executed _per-domain_.
+// Take your expected delay and divide it by the number of domains you have
+// configured (`commonName` + `subjectAlternativeNames`).
 func (o CertificateOutput) PreCheckDelay() pulumi.IntPtrOutput {
 	return o.ApplyT(func(v *Certificate) pulumi.IntPtrOutput { return v.PreCheckDelay }).(pulumi.IntPtrOutput)
 }
 
+// The common name of the root of a preferred
+// alternate certificate chain offered by the CA. The certificates in
+// `issuerPem` will reflect the chain requested, if available, otherwise the
+// default chain will be provided. Forces a new resource when changed.
+//
+// > `preferredChain` can be used to request alternate chains on Let's Encrypt
+// during the transition away from their old cross-signed intermediates. See [this
+// article for more
+// details](https://letsencrypt.org/2020/12/21/extending-android-compatibility.html).
+// In their example titled **"What about the alternate chain?"**, the root you
+// would put in to the `preferredChain` field would be `ISRG Root X1`. The
+// equivalent in the [staging
+// environment](https://letsencrypt.org/docs/staging-environment/) is `(STAGING)
+// Pretend Pear X1`.
 func (o CertificateOutput) PreferredChain() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *Certificate) pulumi.StringPtrOutput { return v.PreferredChain }).(pulumi.StringPtrOutput)
 }
 
+// The certificate's private key, in PEM format, if the
+// certificate was generated from scratch and not with
+// `certificateRequestPem`.  If
+// `certificateRequestPem` was used, this will be blank.
 func (o CertificateOutput) PrivateKeyPem() pulumi.StringOutput {
 	return o.ApplyT(func(v *Certificate) pulumi.StringOutput { return v.PrivateKeyPem }).(pulumi.StringOutput)
 }
 
+// The recursive nameservers that will be
+// used to check for propagation of DNS challenge records. Defaults to your
+// system-configured DNS resolvers.
 func (o CertificateOutput) RecursiveNameservers() pulumi.StringArrayOutput {
 	return o.ApplyT(func(v *Certificate) pulumi.StringArrayOutput { return v.RecursiveNameservers }).(pulumi.StringArrayOutput)
 }
 
+// Enables revocation of a certificate upon destroy,
+// which includes when a resource is re-created. Default is `true`.
 func (o CertificateOutput) RevokeCertificateOnDestroy() pulumi.BoolPtrOutput {
 	return o.ApplyT(func(v *Certificate) pulumi.BoolPtrOutput { return v.RevokeCertificateOnDestroy }).(pulumi.BoolPtrOutput)
 }
 
+// The certificate's subject alternative names,
+// domains that this certificate will also be recognized for. Only valid when not
+// specifying a CSR. Forces a new resource when changed.
 func (o CertificateOutput) SubjectAlternativeNames() pulumi.StringArrayOutput {
 	return o.ApplyT(func(v *Certificate) pulumi.StringArrayOutput { return v.SubjectAlternativeNames }).(pulumi.StringArrayOutput)
 }
 
+// Defines a TLS challenge to use in fulfilling the
+// request.
+//
+// > Only one of `httpChallenge`, `httpWebrootChallenge`, and
+// `httpMemcachedChallenge` can be defined at once. See the section on Using
+// HTTP and TLS challenges for more details on
+// using these and `tlsChallenge`.
 func (o CertificateOutput) TlsChallenge() CertificateTlsChallengePtrOutput {
 	return o.ApplyT(func(v *Certificate) CertificateTlsChallengePtrOutput { return v.TlsChallenge }).(CertificateTlsChallengePtrOutput)
 }

--- a/sdk/go/acme/pulumiTypes.go
+++ b/sdk/go/acme/pulumiTypes.go
@@ -139,7 +139,21 @@ func (o CertificateDnsChallengeArrayOutput) Index(i pulumi.IntInput) Certificate
 }
 
 type CertificateHttpChallenge struct {
-	Port        *int    `pulumi:"port"`
+	// The port that the challenge server listens on. Default: `80`.
+	Port *int `pulumi:"port"`
+	// The proxy header to match against. Default:
+	// `Host`.
+	//
+	// The `proxyHeader` option behaves differently depending on its definition:
+	//
+	// * When set to `Host`, standard host header validation is used.
+	// * When set to `Forwarded`, the server looks in the `Forwarded` header for a
+	//   section matching `host=DOMAIN` where `DOMAIN` is the domain currently being
+	//   resolved by the challenge. See [RFC 7239](https://tools.ietf.org/html/rfc7239)
+	//   for more details.
+	// * When set to an arbitrary header (example: `X-Forwarded-Host`), that header is
+	//   checked for the host entry in the same way the host header would normally be
+	//   checked.
 	ProxyHeader *string `pulumi:"proxyHeader"`
 }
 
@@ -155,7 +169,21 @@ type CertificateHttpChallengeInput interface {
 }
 
 type CertificateHttpChallengeArgs struct {
-	Port        pulumi.IntPtrInput    `pulumi:"port"`
+	// The port that the challenge server listens on. Default: `80`.
+	Port pulumi.IntPtrInput `pulumi:"port"`
+	// The proxy header to match against. Default:
+	// `Host`.
+	//
+	// The `proxyHeader` option behaves differently depending on its definition:
+	//
+	// * When set to `Host`, standard host header validation is used.
+	// * When set to `Forwarded`, the server looks in the `Forwarded` header for a
+	//   section matching `host=DOMAIN` where `DOMAIN` is the domain currently being
+	//   resolved by the challenge. See [RFC 7239](https://tools.ietf.org/html/rfc7239)
+	//   for more details.
+	// * When set to an arbitrary header (example: `X-Forwarded-Host`), that header is
+	//   checked for the host entry in the same way the host header would normally be
+	//   checked.
 	ProxyHeader pulumi.StringPtrInput `pulumi:"proxyHeader"`
 }
 
@@ -254,10 +282,24 @@ func (o CertificateHttpChallengeOutput) ToOutput(ctx context.Context) pulumix.Ou
 	}
 }
 
+// The port that the challenge server listens on. Default: `80`.
 func (o CertificateHttpChallengeOutput) Port() pulumi.IntPtrOutput {
 	return o.ApplyT(func(v CertificateHttpChallenge) *int { return v.Port }).(pulumi.IntPtrOutput)
 }
 
+// The proxy header to match against. Default:
+// `Host`.
+//
+// The `proxyHeader` option behaves differently depending on its definition:
+//
+//   - When set to `Host`, standard host header validation is used.
+//   - When set to `Forwarded`, the server looks in the `Forwarded` header for a
+//     section matching `host=DOMAIN` where `DOMAIN` is the domain currently being
+//     resolved by the challenge. See [RFC 7239](https://tools.ietf.org/html/rfc7239)
+//     for more details.
+//   - When set to an arbitrary header (example: `X-Forwarded-Host`), that header is
+//     checked for the host entry in the same way the host header would normally be
+//     checked.
 func (o CertificateHttpChallengeOutput) ProxyHeader() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v CertificateHttpChallenge) *string { return v.ProxyHeader }).(pulumi.StringPtrOutput)
 }
@@ -292,6 +334,7 @@ func (o CertificateHttpChallengePtrOutput) Elem() CertificateHttpChallengeOutput
 	}).(CertificateHttpChallengeOutput)
 }
 
+// The port that the challenge server listens on. Default: `80`.
 func (o CertificateHttpChallengePtrOutput) Port() pulumi.IntPtrOutput {
 	return o.ApplyT(func(v *CertificateHttpChallenge) *int {
 		if v == nil {
@@ -301,6 +344,19 @@ func (o CertificateHttpChallengePtrOutput) Port() pulumi.IntPtrOutput {
 	}).(pulumi.IntPtrOutput)
 }
 
+// The proxy header to match against. Default:
+// `Host`.
+//
+// The `proxyHeader` option behaves differently depending on its definition:
+//
+//   - When set to `Host`, standard host header validation is used.
+//   - When set to `Forwarded`, the server looks in the `Forwarded` header for a
+//     section matching `host=DOMAIN` where `DOMAIN` is the domain currently being
+//     resolved by the challenge. See [RFC 7239](https://tools.ietf.org/html/rfc7239)
+//     for more details.
+//   - When set to an arbitrary header (example: `X-Forwarded-Host`), that header is
+//     checked for the host entry in the same way the host header would normally be
+//     checked.
 func (o CertificateHttpChallengePtrOutput) ProxyHeader() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *CertificateHttpChallenge) *string {
 		if v == nil {
@@ -311,6 +367,7 @@ func (o CertificateHttpChallengePtrOutput) ProxyHeader() pulumi.StringPtrOutput 
 }
 
 type CertificateHttpMemcachedChallenge struct {
+	// The hosts to publish the record to.
 	Hosts []string `pulumi:"hosts"`
 }
 
@@ -326,6 +383,7 @@ type CertificateHttpMemcachedChallengeInput interface {
 }
 
 type CertificateHttpMemcachedChallengeArgs struct {
+	// The hosts to publish the record to.
 	Hosts pulumi.StringArrayInput `pulumi:"hosts"`
 }
 
@@ -424,6 +482,7 @@ func (o CertificateHttpMemcachedChallengeOutput) ToOutput(ctx context.Context) p
 	}
 }
 
+// The hosts to publish the record to.
 func (o CertificateHttpMemcachedChallengeOutput) Hosts() pulumi.StringArrayOutput {
 	return o.ApplyT(func(v CertificateHttpMemcachedChallenge) []string { return v.Hosts }).(pulumi.StringArrayOutput)
 }
@@ -458,6 +517,7 @@ func (o CertificateHttpMemcachedChallengePtrOutput) Elem() CertificateHttpMemcac
 	}).(CertificateHttpMemcachedChallengeOutput)
 }
 
+// The hosts to publish the record to.
 func (o CertificateHttpMemcachedChallengePtrOutput) Hosts() pulumi.StringArrayOutput {
 	return o.ApplyT(func(v *CertificateHttpMemcachedChallenge) []string {
 		if v == nil {
@@ -468,6 +528,7 @@ func (o CertificateHttpMemcachedChallengePtrOutput) Hosts() pulumi.StringArrayOu
 }
 
 type CertificateHttpWebrootChallenge struct {
+	// The directory to publish the record to.
 	Directory string `pulumi:"directory"`
 }
 
@@ -483,6 +544,7 @@ type CertificateHttpWebrootChallengeInput interface {
 }
 
 type CertificateHttpWebrootChallengeArgs struct {
+	// The directory to publish the record to.
 	Directory pulumi.StringInput `pulumi:"directory"`
 }
 
@@ -581,6 +643,7 @@ func (o CertificateHttpWebrootChallengeOutput) ToOutput(ctx context.Context) pul
 	}
 }
 
+// The directory to publish the record to.
 func (o CertificateHttpWebrootChallengeOutput) Directory() pulumi.StringOutput {
 	return o.ApplyT(func(v CertificateHttpWebrootChallenge) string { return v.Directory }).(pulumi.StringOutput)
 }
@@ -615,6 +678,7 @@ func (o CertificateHttpWebrootChallengePtrOutput) Elem() CertificateHttpWebrootC
 	}).(CertificateHttpWebrootChallengeOutput)
 }
 
+// The directory to publish the record to.
 func (o CertificateHttpWebrootChallengePtrOutput) Directory() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *CertificateHttpWebrootChallenge) *string {
 		if v == nil {
@@ -625,6 +689,7 @@ func (o CertificateHttpWebrootChallengePtrOutput) Directory() pulumi.StringPtrOu
 }
 
 type CertificateTlsChallenge struct {
+	// The port that the challenge server listens on. Default: `443`.
 	Port *int `pulumi:"port"`
 }
 
@@ -640,6 +705,7 @@ type CertificateTlsChallengeInput interface {
 }
 
 type CertificateTlsChallengeArgs struct {
+	// The port that the challenge server listens on. Default: `443`.
 	Port pulumi.IntPtrInput `pulumi:"port"`
 }
 
@@ -738,6 +804,7 @@ func (o CertificateTlsChallengeOutput) ToOutput(ctx context.Context) pulumix.Out
 	}
 }
 
+// The port that the challenge server listens on. Default: `443`.
 func (o CertificateTlsChallengeOutput) Port() pulumi.IntPtrOutput {
 	return o.ApplyT(func(v CertificateTlsChallenge) *int { return v.Port }).(pulumi.IntPtrOutput)
 }
@@ -772,6 +839,7 @@ func (o CertificateTlsChallengePtrOutput) Elem() CertificateTlsChallengeOutput {
 	}).(CertificateTlsChallengeOutput)
 }
 
+// The port that the challenge server listens on. Default: `443`.
 func (o CertificateTlsChallengePtrOutput) Port() pulumi.IntPtrOutput {
 	return o.ApplyT(func(v *CertificateTlsChallenge) *int {
 		if v == nil {

--- a/sdk/nodejs/certificate.ts
+++ b/sdk/nodejs/certificate.ts
@@ -34,30 +34,189 @@ export class Certificate extends pulumi.CustomResource {
         return obj['__pulumiType'] === Certificate.__pulumiType;
     }
 
+    /**
+     * The private key of the account that is
+     * requesting the certificate. Forces a new resource when changed.
+     */
     public readonly accountKeyPem!: pulumi.Output<string>;
+    /**
+     * The common name of the certificate.
+     */
     public /*out*/ readonly certificateDomain!: pulumi.Output<string>;
+    /**
+     * The expiry date of the certificate, laid out in
+     * RFC3339 format (`2006-01-02T15:04:05Z07:00`).
+     */
     public /*out*/ readonly certificateNotAfter!: pulumi.Output<string>;
+    /**
+     * The certificate, any intermediates, and the private key
+     * archived as a PFX file (PKCS12 format, generally used by Microsoft products).
+     * The data is base64 encoded (including padding), and its password is
+     * configurable via the `certificateP12Password`
+     * argument. This field is empty if creating a certificate from a CSR.
+     */
     public /*out*/ readonly certificateP12!: pulumi.Output<string>;
+    /**
+     * Password to be used when generating
+     * the PFX file stored in `certificateP12`. Defaults to an
+     * empty string.
+     */
     public readonly certificateP12Password!: pulumi.Output<string | undefined>;
+    /**
+     * The certificate in PEM format. This does not include the
+     * `issuerPem`. This certificate can be concatenated with `issuerPem` to form
+     * a full chain, e.g. `"${acme_certificate.certificate.certificate_pem}${acme_certificate.certificate.issuer_pem}"`
+     */
     public /*out*/ readonly certificatePem!: pulumi.Output<string>;
+    /**
+     * A pre-created certificate request, such as one
+     * from [`tlsCertRequest`][tls-cert-request], or one from an external source,
+     * in PEM format.  Either this, or the in-resource request options
+     * (`commonName`, `keyType`, and optionally `subjectAlternativeNames`) need
+     * to be specified. Forces a new resource when changed.
+     */
     public readonly certificateRequestPem!: pulumi.Output<string | undefined>;
+    /**
+     * The full URL of the certificate within the ACME CA.
+     */
     public /*out*/ readonly certificateUrl!: pulumi.Output<string>;
+    /**
+     * The certificate's common name, the primary domain that the
+     * certificate will be recognized for. Required when not specifying a CSR. Forces
+     * a new resource when changed.
+     */
     public readonly commonName!: pulumi.Output<string | undefined>;
+    /**
+     * Disable the requirement for full
+     * propagation of the TXT challenge records before proceeding with validation.
+     * Defaults to `false`.
+     *
+     * > See About DNS propagation checks for details
+     * on the `recursiveNameservers` and `disableCompletePropagation` settings.
+     */
     public readonly disableCompletePropagation!: pulumi.Output<boolean | undefined>;
+    /**
+     * The DNS challenges to
+     * use in fulfilling the request.
+     */
     public readonly dnsChallenges!: pulumi.Output<outputs.CertificateDnsChallenge[] | undefined>;
+    /**
+     * Defines an HTTP challenge to use in fulfilling
+     * the request.
+     */
     public readonly httpChallenge!: pulumi.Output<outputs.CertificateHttpChallenge | undefined>;
+    /**
+     * Defines an alternate type of HTTP
+     * challenge that can be used to serve up challenges to a
+     * [Memcached](https://memcached.org/) cluster.
+     */
     public readonly httpMemcachedChallenge!: pulumi.Output<outputs.CertificateHttpMemcachedChallenge | undefined>;
+    /**
+     * Defines an alternate type of HTTP
+     * challenge that can be used to place a file at a location that can be served by
+     * an out-of-band webserver.
+     */
     public readonly httpWebrootChallenge!: pulumi.Output<outputs.CertificateHttpWebrootChallenge | undefined>;
+    /**
+     * The intermediate certificates of the issuer. Multiple
+     * certificates are concatenated in this field when there is more than one
+     * intermediate certificate in the chain.
+     */
     public /*out*/ readonly issuerPem!: pulumi.Output<string>;
+    /**
+     * The key type for the certificate's private key. Can be one of:
+     * `P256` and `P384` (for ECDSA keys of respective length) or `2048`, `4096`, and
+     * `8192` (for RSA keys of respective length). Required when not specifying a
+     * CSR. The default is `2048` (RSA key of 2048 bits). Forces a new resource when
+     * changed.
+     */
     public readonly keyType!: pulumi.Output<string | undefined>;
+    /**
+     * The minimum amount of days remaining on the
+     * expiration of a certificate before a renewal is attempted. The default is
+     * `30`. A value of less than `0` means that the certificate will never be
+     * renewed.
+     */
     public readonly minDaysRemaining!: pulumi.Output<number | undefined>;
+    /**
+     * Enables the [OCSP Stapling Required][ocsp-stapling]
+     * TLS Security Policy extension. Certificates with this extension must include a
+     * valid OCSP Staple in the TLS handshake for the connection to succeed.
+     * Defaults to `false`. Note that this option has no effect when using an
+     * external CSR - it must be enabled in the CSR itself. Forces a new resource
+     * when changed.
+     *
+     * [ocsp-stapling]: https://letsencrypt.org/docs/integration-guide/#implement-ocsp-stapling
+     *
+     * > OCSP stapling requires specific webserver configuration to support the
+     * downloading of the staple from the CA's OCSP endpoints, and should be configured
+     * to tolerate prolonged outages of the OCSP service. Consider this when using
+     * `mustStaple`, and only enable it if you are sure your webserver or service
+     * provider can be configured correctly.
+     */
     public readonly mustStaple!: pulumi.Output<boolean | undefined>;
+    /**
+     * Insert a delay after _every_ DNS challenge
+     * record to allow for extra time for DNS propagation before the certificate is
+     * requested. Use this option if you observe issues with requesting certificates
+     * even when DNS challenge records get added successfully. Units are in seconds.
+     * Defaults to 0 (no delay).
+     *
+     * > Be careful with `preCheckDelay` since the delay is executed _per-domain_.
+     * Take your expected delay and divide it by the number of domains you have
+     * configured (`commonName` + `subjectAlternativeNames`).
+     */
     public readonly preCheckDelay!: pulumi.Output<number | undefined>;
+    /**
+     * The common name of the root of a preferred
+     * alternate certificate chain offered by the CA. The certificates in
+     * `issuerPem` will reflect the chain requested, if available, otherwise the
+     * default chain will be provided. Forces a new resource when changed.
+     *
+     * > `preferredChain` can be used to request alternate chains on Let's Encrypt
+     * during the transition away from their old cross-signed intermediates. See [this
+     * article for more
+     * details](https://letsencrypt.org/2020/12/21/extending-android-compatibility.html).
+     * In their example titled **"What about the alternate chain?"**, the root you
+     * would put in to the `preferredChain` field would be `ISRG Root X1`. The
+     * equivalent in the [staging
+     * environment](https://letsencrypt.org/docs/staging-environment/) is `(STAGING)
+     * Pretend Pear X1`.
+     */
     public readonly preferredChain!: pulumi.Output<string | undefined>;
+    /**
+     * The certificate's private key, in PEM format, if the
+     * certificate was generated from scratch and not with
+     * `certificateRequestPem`.  If
+     * `certificateRequestPem` was used, this will be blank.
+     */
     public /*out*/ readonly privateKeyPem!: pulumi.Output<string>;
+    /**
+     * The recursive nameservers that will be
+     * used to check for propagation of DNS challenge records. Defaults to your
+     * system-configured DNS resolvers.
+     */
     public readonly recursiveNameservers!: pulumi.Output<string[] | undefined>;
+    /**
+     * Enables revocation of a certificate upon destroy,
+     * which includes when a resource is re-created. Default is `true`.
+     */
     public readonly revokeCertificateOnDestroy!: pulumi.Output<boolean | undefined>;
+    /**
+     * The certificate's subject alternative names,
+     * domains that this certificate will also be recognized for. Only valid when not
+     * specifying a CSR. Forces a new resource when changed.
+     */
     public readonly subjectAlternativeNames!: pulumi.Output<string[] | undefined>;
+    /**
+     * Defines a TLS challenge to use in fulfilling the
+     * request.
+     *
+     * > Only one of `httpChallenge`, `httpWebrootChallenge`, and
+     * `httpMemcachedChallenge` can be defined at once. See the section on Using
+     * HTTP and TLS challenges for more details on
+     * using these and `tlsChallenge`.
+     */
     public readonly tlsChallenge!: pulumi.Output<outputs.CertificateTlsChallenge | undefined>;
 
     /**
@@ -140,30 +299,189 @@ export class Certificate extends pulumi.CustomResource {
  * Input properties used for looking up and filtering Certificate resources.
  */
 export interface CertificateState {
+    /**
+     * The private key of the account that is
+     * requesting the certificate. Forces a new resource when changed.
+     */
     accountKeyPem?: pulumi.Input<string>;
+    /**
+     * The common name of the certificate.
+     */
     certificateDomain?: pulumi.Input<string>;
+    /**
+     * The expiry date of the certificate, laid out in
+     * RFC3339 format (`2006-01-02T15:04:05Z07:00`).
+     */
     certificateNotAfter?: pulumi.Input<string>;
+    /**
+     * The certificate, any intermediates, and the private key
+     * archived as a PFX file (PKCS12 format, generally used by Microsoft products).
+     * The data is base64 encoded (including padding), and its password is
+     * configurable via the `certificateP12Password`
+     * argument. This field is empty if creating a certificate from a CSR.
+     */
     certificateP12?: pulumi.Input<string>;
+    /**
+     * Password to be used when generating
+     * the PFX file stored in `certificateP12`. Defaults to an
+     * empty string.
+     */
     certificateP12Password?: pulumi.Input<string>;
+    /**
+     * The certificate in PEM format. This does not include the
+     * `issuerPem`. This certificate can be concatenated with `issuerPem` to form
+     * a full chain, e.g. `"${acme_certificate.certificate.certificate_pem}${acme_certificate.certificate.issuer_pem}"`
+     */
     certificatePem?: pulumi.Input<string>;
+    /**
+     * A pre-created certificate request, such as one
+     * from [`tlsCertRequest`][tls-cert-request], or one from an external source,
+     * in PEM format.  Either this, or the in-resource request options
+     * (`commonName`, `keyType`, and optionally `subjectAlternativeNames`) need
+     * to be specified. Forces a new resource when changed.
+     */
     certificateRequestPem?: pulumi.Input<string>;
+    /**
+     * The full URL of the certificate within the ACME CA.
+     */
     certificateUrl?: pulumi.Input<string>;
+    /**
+     * The certificate's common name, the primary domain that the
+     * certificate will be recognized for. Required when not specifying a CSR. Forces
+     * a new resource when changed.
+     */
     commonName?: pulumi.Input<string>;
+    /**
+     * Disable the requirement for full
+     * propagation of the TXT challenge records before proceeding with validation.
+     * Defaults to `false`.
+     *
+     * > See About DNS propagation checks for details
+     * on the `recursiveNameservers` and `disableCompletePropagation` settings.
+     */
     disableCompletePropagation?: pulumi.Input<boolean>;
+    /**
+     * The DNS challenges to
+     * use in fulfilling the request.
+     */
     dnsChallenges?: pulumi.Input<pulumi.Input<inputs.CertificateDnsChallenge>[]>;
+    /**
+     * Defines an HTTP challenge to use in fulfilling
+     * the request.
+     */
     httpChallenge?: pulumi.Input<inputs.CertificateHttpChallenge>;
+    /**
+     * Defines an alternate type of HTTP
+     * challenge that can be used to serve up challenges to a
+     * [Memcached](https://memcached.org/) cluster.
+     */
     httpMemcachedChallenge?: pulumi.Input<inputs.CertificateHttpMemcachedChallenge>;
+    /**
+     * Defines an alternate type of HTTP
+     * challenge that can be used to place a file at a location that can be served by
+     * an out-of-band webserver.
+     */
     httpWebrootChallenge?: pulumi.Input<inputs.CertificateHttpWebrootChallenge>;
+    /**
+     * The intermediate certificates of the issuer. Multiple
+     * certificates are concatenated in this field when there is more than one
+     * intermediate certificate in the chain.
+     */
     issuerPem?: pulumi.Input<string>;
+    /**
+     * The key type for the certificate's private key. Can be one of:
+     * `P256` and `P384` (for ECDSA keys of respective length) or `2048`, `4096`, and
+     * `8192` (for RSA keys of respective length). Required when not specifying a
+     * CSR. The default is `2048` (RSA key of 2048 bits). Forces a new resource when
+     * changed.
+     */
     keyType?: pulumi.Input<string>;
+    /**
+     * The minimum amount of days remaining on the
+     * expiration of a certificate before a renewal is attempted. The default is
+     * `30`. A value of less than `0` means that the certificate will never be
+     * renewed.
+     */
     minDaysRemaining?: pulumi.Input<number>;
+    /**
+     * Enables the [OCSP Stapling Required][ocsp-stapling]
+     * TLS Security Policy extension. Certificates with this extension must include a
+     * valid OCSP Staple in the TLS handshake for the connection to succeed.
+     * Defaults to `false`. Note that this option has no effect when using an
+     * external CSR - it must be enabled in the CSR itself. Forces a new resource
+     * when changed.
+     *
+     * [ocsp-stapling]: https://letsencrypt.org/docs/integration-guide/#implement-ocsp-stapling
+     *
+     * > OCSP stapling requires specific webserver configuration to support the
+     * downloading of the staple from the CA's OCSP endpoints, and should be configured
+     * to tolerate prolonged outages of the OCSP service. Consider this when using
+     * `mustStaple`, and only enable it if you are sure your webserver or service
+     * provider can be configured correctly.
+     */
     mustStaple?: pulumi.Input<boolean>;
+    /**
+     * Insert a delay after _every_ DNS challenge
+     * record to allow for extra time for DNS propagation before the certificate is
+     * requested. Use this option if you observe issues with requesting certificates
+     * even when DNS challenge records get added successfully. Units are in seconds.
+     * Defaults to 0 (no delay).
+     *
+     * > Be careful with `preCheckDelay` since the delay is executed _per-domain_.
+     * Take your expected delay and divide it by the number of domains you have
+     * configured (`commonName` + `subjectAlternativeNames`).
+     */
     preCheckDelay?: pulumi.Input<number>;
+    /**
+     * The common name of the root of a preferred
+     * alternate certificate chain offered by the CA. The certificates in
+     * `issuerPem` will reflect the chain requested, if available, otherwise the
+     * default chain will be provided. Forces a new resource when changed.
+     *
+     * > `preferredChain` can be used to request alternate chains on Let's Encrypt
+     * during the transition away from their old cross-signed intermediates. See [this
+     * article for more
+     * details](https://letsencrypt.org/2020/12/21/extending-android-compatibility.html).
+     * In their example titled **"What about the alternate chain?"**, the root you
+     * would put in to the `preferredChain` field would be `ISRG Root X1`. The
+     * equivalent in the [staging
+     * environment](https://letsencrypt.org/docs/staging-environment/) is `(STAGING)
+     * Pretend Pear X1`.
+     */
     preferredChain?: pulumi.Input<string>;
+    /**
+     * The certificate's private key, in PEM format, if the
+     * certificate was generated from scratch and not with
+     * `certificateRequestPem`.  If
+     * `certificateRequestPem` was used, this will be blank.
+     */
     privateKeyPem?: pulumi.Input<string>;
+    /**
+     * The recursive nameservers that will be
+     * used to check for propagation of DNS challenge records. Defaults to your
+     * system-configured DNS resolvers.
+     */
     recursiveNameservers?: pulumi.Input<pulumi.Input<string>[]>;
+    /**
+     * Enables revocation of a certificate upon destroy,
+     * which includes when a resource is re-created. Default is `true`.
+     */
     revokeCertificateOnDestroy?: pulumi.Input<boolean>;
+    /**
+     * The certificate's subject alternative names,
+     * domains that this certificate will also be recognized for. Only valid when not
+     * specifying a CSR. Forces a new resource when changed.
+     */
     subjectAlternativeNames?: pulumi.Input<pulumi.Input<string>[]>;
+    /**
+     * Defines a TLS challenge to use in fulfilling the
+     * request.
+     *
+     * > Only one of `httpChallenge`, `httpWebrootChallenge`, and
+     * `httpMemcachedChallenge` can be defined at once. See the section on Using
+     * HTTP and TLS challenges for more details on
+     * using these and `tlsChallenge`.
+     */
     tlsChallenge?: pulumi.Input<inputs.CertificateTlsChallenge>;
 }
 
@@ -171,22 +489,148 @@ export interface CertificateState {
  * The set of arguments for constructing a Certificate resource.
  */
 export interface CertificateArgs {
+    /**
+     * The private key of the account that is
+     * requesting the certificate. Forces a new resource when changed.
+     */
     accountKeyPem: pulumi.Input<string>;
+    /**
+     * Password to be used when generating
+     * the PFX file stored in `certificateP12`. Defaults to an
+     * empty string.
+     */
     certificateP12Password?: pulumi.Input<string>;
+    /**
+     * A pre-created certificate request, such as one
+     * from [`tlsCertRequest`][tls-cert-request], or one from an external source,
+     * in PEM format.  Either this, or the in-resource request options
+     * (`commonName`, `keyType`, and optionally `subjectAlternativeNames`) need
+     * to be specified. Forces a new resource when changed.
+     */
     certificateRequestPem?: pulumi.Input<string>;
+    /**
+     * The certificate's common name, the primary domain that the
+     * certificate will be recognized for. Required when not specifying a CSR. Forces
+     * a new resource when changed.
+     */
     commonName?: pulumi.Input<string>;
+    /**
+     * Disable the requirement for full
+     * propagation of the TXT challenge records before proceeding with validation.
+     * Defaults to `false`.
+     *
+     * > See About DNS propagation checks for details
+     * on the `recursiveNameservers` and `disableCompletePropagation` settings.
+     */
     disableCompletePropagation?: pulumi.Input<boolean>;
+    /**
+     * The DNS challenges to
+     * use in fulfilling the request.
+     */
     dnsChallenges?: pulumi.Input<pulumi.Input<inputs.CertificateDnsChallenge>[]>;
+    /**
+     * Defines an HTTP challenge to use in fulfilling
+     * the request.
+     */
     httpChallenge?: pulumi.Input<inputs.CertificateHttpChallenge>;
+    /**
+     * Defines an alternate type of HTTP
+     * challenge that can be used to serve up challenges to a
+     * [Memcached](https://memcached.org/) cluster.
+     */
     httpMemcachedChallenge?: pulumi.Input<inputs.CertificateHttpMemcachedChallenge>;
+    /**
+     * Defines an alternate type of HTTP
+     * challenge that can be used to place a file at a location that can be served by
+     * an out-of-band webserver.
+     */
     httpWebrootChallenge?: pulumi.Input<inputs.CertificateHttpWebrootChallenge>;
+    /**
+     * The key type for the certificate's private key. Can be one of:
+     * `P256` and `P384` (for ECDSA keys of respective length) or `2048`, `4096`, and
+     * `8192` (for RSA keys of respective length). Required when not specifying a
+     * CSR. The default is `2048` (RSA key of 2048 bits). Forces a new resource when
+     * changed.
+     */
     keyType?: pulumi.Input<string>;
+    /**
+     * The minimum amount of days remaining on the
+     * expiration of a certificate before a renewal is attempted. The default is
+     * `30`. A value of less than `0` means that the certificate will never be
+     * renewed.
+     */
     minDaysRemaining?: pulumi.Input<number>;
+    /**
+     * Enables the [OCSP Stapling Required][ocsp-stapling]
+     * TLS Security Policy extension. Certificates with this extension must include a
+     * valid OCSP Staple in the TLS handshake for the connection to succeed.
+     * Defaults to `false`. Note that this option has no effect when using an
+     * external CSR - it must be enabled in the CSR itself. Forces a new resource
+     * when changed.
+     *
+     * [ocsp-stapling]: https://letsencrypt.org/docs/integration-guide/#implement-ocsp-stapling
+     *
+     * > OCSP stapling requires specific webserver configuration to support the
+     * downloading of the staple from the CA's OCSP endpoints, and should be configured
+     * to tolerate prolonged outages of the OCSP service. Consider this when using
+     * `mustStaple`, and only enable it if you are sure your webserver or service
+     * provider can be configured correctly.
+     */
     mustStaple?: pulumi.Input<boolean>;
+    /**
+     * Insert a delay after _every_ DNS challenge
+     * record to allow for extra time for DNS propagation before the certificate is
+     * requested. Use this option if you observe issues with requesting certificates
+     * even when DNS challenge records get added successfully. Units are in seconds.
+     * Defaults to 0 (no delay).
+     *
+     * > Be careful with `preCheckDelay` since the delay is executed _per-domain_.
+     * Take your expected delay and divide it by the number of domains you have
+     * configured (`commonName` + `subjectAlternativeNames`).
+     */
     preCheckDelay?: pulumi.Input<number>;
+    /**
+     * The common name of the root of a preferred
+     * alternate certificate chain offered by the CA. The certificates in
+     * `issuerPem` will reflect the chain requested, if available, otherwise the
+     * default chain will be provided. Forces a new resource when changed.
+     *
+     * > `preferredChain` can be used to request alternate chains on Let's Encrypt
+     * during the transition away from their old cross-signed intermediates. See [this
+     * article for more
+     * details](https://letsencrypt.org/2020/12/21/extending-android-compatibility.html).
+     * In their example titled **"What about the alternate chain?"**, the root you
+     * would put in to the `preferredChain` field would be `ISRG Root X1`. The
+     * equivalent in the [staging
+     * environment](https://letsencrypt.org/docs/staging-environment/) is `(STAGING)
+     * Pretend Pear X1`.
+     */
     preferredChain?: pulumi.Input<string>;
+    /**
+     * The recursive nameservers that will be
+     * used to check for propagation of DNS challenge records. Defaults to your
+     * system-configured DNS resolvers.
+     */
     recursiveNameservers?: pulumi.Input<pulumi.Input<string>[]>;
+    /**
+     * Enables revocation of a certificate upon destroy,
+     * which includes when a resource is re-created. Default is `true`.
+     */
     revokeCertificateOnDestroy?: pulumi.Input<boolean>;
+    /**
+     * The certificate's subject alternative names,
+     * domains that this certificate will also be recognized for. Only valid when not
+     * specifying a CSR. Forces a new resource when changed.
+     */
     subjectAlternativeNames?: pulumi.Input<pulumi.Input<string>[]>;
+    /**
+     * Defines a TLS challenge to use in fulfilling the
+     * request.
+     *
+     * > Only one of `httpChallenge`, `httpWebrootChallenge`, and
+     * `httpMemcachedChallenge` can be defined at once. See the section on Using
+     * HTTP and TLS challenges for more details on
+     * using these and `tlsChallenge`.
+     */
     tlsChallenge?: pulumi.Input<inputs.CertificateTlsChallenge>;
 }

--- a/sdk/nodejs/types/input.ts
+++ b/sdk/nodejs/types/input.ts
@@ -11,19 +11,46 @@ export interface CertificateDnsChallenge {
 }
 
 export interface CertificateHttpChallenge {
+    /**
+     * The port that the challenge server listens on. Default: `80`.
+     */
     port?: pulumi.Input<number>;
+    /**
+     * The proxy header to match against. Default:
+     * `Host`.
+     *
+     * The `proxyHeader` option behaves differently depending on its definition:
+     *
+     * * When set to `Host`, standard host header validation is used.
+     * * When set to `Forwarded`, the server looks in the `Forwarded` header for a
+     * section matching `host=DOMAIN` where `DOMAIN` is the domain currently being
+     * resolved by the challenge. See [RFC 7239](https://tools.ietf.org/html/rfc7239)
+     * for more details.
+     * * When set to an arbitrary header (example: `X-Forwarded-Host`), that header is
+     * checked for the host entry in the same way the host header would normally be
+     * checked.
+     */
     proxyHeader?: pulumi.Input<string>;
 }
 
 export interface CertificateHttpMemcachedChallenge {
+    /**
+     * The hosts to publish the record to.
+     */
     hosts: pulumi.Input<pulumi.Input<string>[]>;
 }
 
 export interface CertificateHttpWebrootChallenge {
+    /**
+     * The directory to publish the record to.
+     */
     directory: pulumi.Input<string>;
 }
 
 export interface CertificateTlsChallenge {
+    /**
+     * The port that the challenge server listens on. Default: `443`.
+     */
     port?: pulumi.Input<number>;
 }
 

--- a/sdk/nodejs/types/output.ts
+++ b/sdk/nodejs/types/output.ts
@@ -11,19 +11,46 @@ export interface CertificateDnsChallenge {
 }
 
 export interface CertificateHttpChallenge {
+    /**
+     * The port that the challenge server listens on. Default: `80`.
+     */
     port?: number;
+    /**
+     * The proxy header to match against. Default:
+     * `Host`.
+     *
+     * The `proxyHeader` option behaves differently depending on its definition:
+     *
+     * * When set to `Host`, standard host header validation is used.
+     * * When set to `Forwarded`, the server looks in the `Forwarded` header for a
+     * section matching `host=DOMAIN` where `DOMAIN` is the domain currently being
+     * resolved by the challenge. See [RFC 7239](https://tools.ietf.org/html/rfc7239)
+     * for more details.
+     * * When set to an arbitrary header (example: `X-Forwarded-Host`), that header is
+     * checked for the host entry in the same way the host header would normally be
+     * checked.
+     */
     proxyHeader?: string;
 }
 
 export interface CertificateHttpMemcachedChallenge {
+    /**
+     * The hosts to publish the record to.
+     */
     hosts: string[];
 }
 
 export interface CertificateHttpWebrootChallenge {
+    /**
+     * The directory to publish the record to.
+     */
     directory: string;
 }
 
 export interface CertificateTlsChallenge {
+    /**
+     * The port that the challenge server listens on. Default: `443`.
+     */
     port?: number;
 }
 

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -11,13 +11,13 @@ This package is available for several languages/platforms:
 To use from JavaScript or TypeScript in Node.js, install using either `npm`:
 
 ```bash
-npm install @pulumi/acme
+npm install @pulumiverse/acme
 ```
 
 or `yarn`:
 
 ```bash
-yarn add @pulumi/acme
+yarn add @pulumiverse/acme
 ```
 
 ### Python
@@ -25,7 +25,7 @@ yarn add @pulumi/acme
 To use from Python, install using `pip`:
 
 ```bash
-pip install pulumi_acme
+pip install pulumiverse_acme
 ```
 
 ### Go
@@ -33,7 +33,7 @@ pip install pulumi_acme
 To use from Go, use `go get` to grab the latest version of the library:
 
 ```bash
-go get github.com/pulumi/pulumi-acme/sdk/go/...
+go get github.com/pulumiverse/pulumi-acme/sdk/go/...
 ```
 
 ### .NET
@@ -41,15 +41,8 @@ go get github.com/pulumi/pulumi-acme/sdk/go/...
 To use from .NET, install using `dotnet add package`:
 
 ```bash
-dotnet add package Pulumi.ACME
+dotnet add package Pulumiverse.Acme
 ```
-
-## Configuration
-
-The following configuration points are available for the `acme` provider:
-
-- `acme:apiKey` (environment: `ACME_API_KEY`) - the API key for `acme`
-- `acme:region` (environment: `ACME_REGION`) - the region in which to deploy resources
 
 ## Reference
 

--- a/sdk/python/pulumiverse_acme/_inputs.py
+++ b/sdk/python/pulumiverse_acme/_inputs.py
@@ -51,6 +51,22 @@ class CertificateHttpChallengeArgs:
     def __init__(__self__, *,
                  port: Optional[pulumi.Input[int]] = None,
                  proxy_header: Optional[pulumi.Input[str]] = None):
+        """
+        :param pulumi.Input[int] port: The port that the challenge server listens on. Default: `80`.
+        :param pulumi.Input[str] proxy_header: The proxy header to match against. Default:
+               `Host`.
+               
+               The `proxy_header` option behaves differently depending on its definition:
+               
+               * When set to `Host`, standard host header validation is used.
+               * When set to `Forwarded`, the server looks in the `Forwarded` header for a
+               section matching `host=DOMAIN` where `DOMAIN` is the domain currently being
+               resolved by the challenge. See [RFC 7239](https://tools.ietf.org/html/rfc7239)
+               for more details.
+               * When set to an arbitrary header (example: `X-Forwarded-Host`), that header is
+               checked for the host entry in the same way the host header would normally be
+               checked.
+        """
         if port is not None:
             pulumi.set(__self__, "port", port)
         if proxy_header is not None:
@@ -59,6 +75,9 @@ class CertificateHttpChallengeArgs:
     @property
     @pulumi.getter
     def port(self) -> Optional[pulumi.Input[int]]:
+        """
+        The port that the challenge server listens on. Default: `80`.
+        """
         return pulumi.get(self, "port")
 
     @port.setter
@@ -68,6 +87,21 @@ class CertificateHttpChallengeArgs:
     @property
     @pulumi.getter(name="proxyHeader")
     def proxy_header(self) -> Optional[pulumi.Input[str]]:
+        """
+        The proxy header to match against. Default:
+        `Host`.
+
+        The `proxy_header` option behaves differently depending on its definition:
+
+        * When set to `Host`, standard host header validation is used.
+        * When set to `Forwarded`, the server looks in the `Forwarded` header for a
+        section matching `host=DOMAIN` where `DOMAIN` is the domain currently being
+        resolved by the challenge. See [RFC 7239](https://tools.ietf.org/html/rfc7239)
+        for more details.
+        * When set to an arbitrary header (example: `X-Forwarded-Host`), that header is
+        checked for the host entry in the same way the host header would normally be
+        checked.
+        """
         return pulumi.get(self, "proxy_header")
 
     @proxy_header.setter
@@ -79,11 +113,17 @@ class CertificateHttpChallengeArgs:
 class CertificateHttpMemcachedChallengeArgs:
     def __init__(__self__, *,
                  hosts: pulumi.Input[Sequence[pulumi.Input[str]]]):
+        """
+        :param pulumi.Input[Sequence[pulumi.Input[str]]] hosts: The hosts to publish the record to.
+        """
         pulumi.set(__self__, "hosts", hosts)
 
     @property
     @pulumi.getter
     def hosts(self) -> pulumi.Input[Sequence[pulumi.Input[str]]]:
+        """
+        The hosts to publish the record to.
+        """
         return pulumi.get(self, "hosts")
 
     @hosts.setter
@@ -95,11 +135,17 @@ class CertificateHttpMemcachedChallengeArgs:
 class CertificateHttpWebrootChallengeArgs:
     def __init__(__self__, *,
                  directory: pulumi.Input[str]):
+        """
+        :param pulumi.Input[str] directory: The directory to publish the record to.
+        """
         pulumi.set(__self__, "directory", directory)
 
     @property
     @pulumi.getter
     def directory(self) -> pulumi.Input[str]:
+        """
+        The directory to publish the record to.
+        """
         return pulumi.get(self, "directory")
 
     @directory.setter
@@ -111,12 +157,18 @@ class CertificateHttpWebrootChallengeArgs:
 class CertificateTlsChallengeArgs:
     def __init__(__self__, *,
                  port: Optional[pulumi.Input[int]] = None):
+        """
+        :param pulumi.Input[int] port: The port that the challenge server listens on. Default: `443`.
+        """
         if port is not None:
             pulumi.set(__self__, "port", port)
 
     @property
     @pulumi.getter
     def port(self) -> Optional[pulumi.Input[int]]:
+        """
+        The port that the challenge server listens on. Default: `443`.
+        """
         return pulumi.get(self, "port")
 
     @port.setter

--- a/sdk/python/pulumiverse_acme/certificate.py
+++ b/sdk/python/pulumiverse_acme/certificate.py
@@ -36,6 +36,96 @@ class CertificateArgs:
                  tls_challenge: Optional[pulumi.Input['CertificateTlsChallengeArgs']] = None):
         """
         The set of arguments for constructing a Certificate resource.
+        :param pulumi.Input[str] account_key_pem: The private key of the account that is
+               requesting the certificate. Forces a new resource when changed.
+        :param pulumi.Input[str] certificate_p12_password: Password to be used when generating
+               the PFX file stored in `certificate_p12`. Defaults to an
+               empty string.
+        :param pulumi.Input[str] certificate_request_pem: A pre-created certificate request, such as one
+               from [`tls_cert_request`][tls-cert-request], or one from an external source,
+               in PEM format.  Either this, or the in-resource request options
+               (`common_name`, `key_type`, and optionally `subject_alternative_names`) need
+               to be specified. Forces a new resource when changed.
+        :param pulumi.Input[str] common_name: The certificate's common name, the primary domain that the
+               certificate will be recognized for. Required when not specifying a CSR. Forces
+               a new resource when changed.
+        :param pulumi.Input[bool] disable_complete_propagation: Disable the requirement for full
+               propagation of the TXT challenge records before proceeding with validation.
+               Defaults to `false`.
+               
+               > See About DNS propagation checks for details
+               on the `recursive_nameservers` and `disable_complete_propagation` settings.
+        :param pulumi.Input[Sequence[pulumi.Input['CertificateDnsChallengeArgs']]] dns_challenges: The DNS challenges to
+               use in fulfilling the request.
+        :param pulumi.Input['CertificateHttpChallengeArgs'] http_challenge: Defines an HTTP challenge to use in fulfilling
+               the request.
+        :param pulumi.Input['CertificateHttpMemcachedChallengeArgs'] http_memcached_challenge: Defines an alternate type of HTTP
+               challenge that can be used to serve up challenges to a
+               [Memcached](https://memcached.org/) cluster.
+        :param pulumi.Input['CertificateHttpWebrootChallengeArgs'] http_webroot_challenge: Defines an alternate type of HTTP
+               challenge that can be used to place a file at a location that can be served by
+               an out-of-band webserver.
+        :param pulumi.Input[str] key_type: The key type for the certificate's private key. Can be one of:
+               `P256` and `P384` (for ECDSA keys of respective length) or `2048`, `4096`, and
+               `8192` (for RSA keys of respective length). Required when not specifying a
+               CSR. The default is `2048` (RSA key of 2048 bits). Forces a new resource when
+               changed.
+        :param pulumi.Input[int] min_days_remaining: The minimum amount of days remaining on the
+               expiration of a certificate before a renewal is attempted. The default is
+               `30`. A value of less than `0` means that the certificate will never be
+               renewed.
+        :param pulumi.Input[bool] must_staple: Enables the [OCSP Stapling Required][ocsp-stapling]
+               TLS Security Policy extension. Certificates with this extension must include a
+               valid OCSP Staple in the TLS handshake for the connection to succeed.
+               Defaults to `false`. Note that this option has no effect when using an
+               external CSR - it must be enabled in the CSR itself. Forces a new resource
+               when changed.
+               
+               [ocsp-stapling]: https://letsencrypt.org/docs/integration-guide/#implement-ocsp-stapling
+               
+               > OCSP stapling requires specific webserver configuration to support the
+               downloading of the staple from the CA's OCSP endpoints, and should be configured
+               to tolerate prolonged outages of the OCSP service. Consider this when using
+               `must_staple`, and only enable it if you are sure your webserver or service
+               provider can be configured correctly.
+        :param pulumi.Input[int] pre_check_delay: Insert a delay after _every_ DNS challenge
+               record to allow for extra time for DNS propagation before the certificate is
+               requested. Use this option if you observe issues with requesting certificates
+               even when DNS challenge records get added successfully. Units are in seconds.
+               Defaults to 0 (no delay).
+               
+               > Be careful with `pre_check_delay` since the delay is executed _per-domain_.
+               Take your expected delay and divide it by the number of domains you have
+               configured (`common_name` + `subject_alternative_names`).
+        :param pulumi.Input[str] preferred_chain: The common name of the root of a preferred
+               alternate certificate chain offered by the CA. The certificates in
+               `issuer_pem` will reflect the chain requested, if available, otherwise the
+               default chain will be provided. Forces a new resource when changed.
+               
+               > `preferred_chain` can be used to request alternate chains on Let's Encrypt
+               during the transition away from their old cross-signed intermediates. See [this
+               article for more
+               details](https://letsencrypt.org/2020/12/21/extending-android-compatibility.html).
+               In their example titled **"What about the alternate chain?"**, the root you
+               would put in to the `preferred_chain` field would be `ISRG Root X1`. The
+               equivalent in the [staging
+               environment](https://letsencrypt.org/docs/staging-environment/) is `(STAGING)
+               Pretend Pear X1`.
+        :param pulumi.Input[Sequence[pulumi.Input[str]]] recursive_nameservers: The recursive nameservers that will be
+               used to check for propagation of DNS challenge records. Defaults to your
+               system-configured DNS resolvers.
+        :param pulumi.Input[bool] revoke_certificate_on_destroy: Enables revocation of a certificate upon destroy,
+               which includes when a resource is re-created. Default is `true`.
+        :param pulumi.Input[Sequence[pulumi.Input[str]]] subject_alternative_names: The certificate's subject alternative names,
+               domains that this certificate will also be recognized for. Only valid when not
+               specifying a CSR. Forces a new resource when changed.
+        :param pulumi.Input['CertificateTlsChallengeArgs'] tls_challenge: Defines a TLS challenge to use in fulfilling the
+               request.
+               
+               > Only one of `http_challenge`, `http_webroot_challenge`, and
+               `http_memcached_challenge` can be defined at once. See the section on Using
+               HTTP and TLS challenges for more details on
+               using these and `tls_challenge`.
         """
         pulumi.set(__self__, "account_key_pem", account_key_pem)
         if certificate_p12_password is not None:
@@ -76,6 +166,10 @@ class CertificateArgs:
     @property
     @pulumi.getter(name="accountKeyPem")
     def account_key_pem(self) -> pulumi.Input[str]:
+        """
+        The private key of the account that is
+        requesting the certificate. Forces a new resource when changed.
+        """
         return pulumi.get(self, "account_key_pem")
 
     @account_key_pem.setter
@@ -85,6 +179,11 @@ class CertificateArgs:
     @property
     @pulumi.getter(name="certificateP12Password")
     def certificate_p12_password(self) -> Optional[pulumi.Input[str]]:
+        """
+        Password to be used when generating
+        the PFX file stored in `certificate_p12`. Defaults to an
+        empty string.
+        """
         return pulumi.get(self, "certificate_p12_password")
 
     @certificate_p12_password.setter
@@ -94,6 +193,13 @@ class CertificateArgs:
     @property
     @pulumi.getter(name="certificateRequestPem")
     def certificate_request_pem(self) -> Optional[pulumi.Input[str]]:
+        """
+        A pre-created certificate request, such as one
+        from [`tls_cert_request`][tls-cert-request], or one from an external source,
+        in PEM format.  Either this, or the in-resource request options
+        (`common_name`, `key_type`, and optionally `subject_alternative_names`) need
+        to be specified. Forces a new resource when changed.
+        """
         return pulumi.get(self, "certificate_request_pem")
 
     @certificate_request_pem.setter
@@ -103,6 +209,11 @@ class CertificateArgs:
     @property
     @pulumi.getter(name="commonName")
     def common_name(self) -> Optional[pulumi.Input[str]]:
+        """
+        The certificate's common name, the primary domain that the
+        certificate will be recognized for. Required when not specifying a CSR. Forces
+        a new resource when changed.
+        """
         return pulumi.get(self, "common_name")
 
     @common_name.setter
@@ -112,6 +223,14 @@ class CertificateArgs:
     @property
     @pulumi.getter(name="disableCompletePropagation")
     def disable_complete_propagation(self) -> Optional[pulumi.Input[bool]]:
+        """
+        Disable the requirement for full
+        propagation of the TXT challenge records before proceeding with validation.
+        Defaults to `false`.
+
+        > See About DNS propagation checks for details
+        on the `recursive_nameservers` and `disable_complete_propagation` settings.
+        """
         return pulumi.get(self, "disable_complete_propagation")
 
     @disable_complete_propagation.setter
@@ -121,6 +240,10 @@ class CertificateArgs:
     @property
     @pulumi.getter(name="dnsChallenges")
     def dns_challenges(self) -> Optional[pulumi.Input[Sequence[pulumi.Input['CertificateDnsChallengeArgs']]]]:
+        """
+        The DNS challenges to
+        use in fulfilling the request.
+        """
         return pulumi.get(self, "dns_challenges")
 
     @dns_challenges.setter
@@ -130,6 +253,10 @@ class CertificateArgs:
     @property
     @pulumi.getter(name="httpChallenge")
     def http_challenge(self) -> Optional[pulumi.Input['CertificateHttpChallengeArgs']]:
+        """
+        Defines an HTTP challenge to use in fulfilling
+        the request.
+        """
         return pulumi.get(self, "http_challenge")
 
     @http_challenge.setter
@@ -139,6 +266,11 @@ class CertificateArgs:
     @property
     @pulumi.getter(name="httpMemcachedChallenge")
     def http_memcached_challenge(self) -> Optional[pulumi.Input['CertificateHttpMemcachedChallengeArgs']]:
+        """
+        Defines an alternate type of HTTP
+        challenge that can be used to serve up challenges to a
+        [Memcached](https://memcached.org/) cluster.
+        """
         return pulumi.get(self, "http_memcached_challenge")
 
     @http_memcached_challenge.setter
@@ -148,6 +280,11 @@ class CertificateArgs:
     @property
     @pulumi.getter(name="httpWebrootChallenge")
     def http_webroot_challenge(self) -> Optional[pulumi.Input['CertificateHttpWebrootChallengeArgs']]:
+        """
+        Defines an alternate type of HTTP
+        challenge that can be used to place a file at a location that can be served by
+        an out-of-band webserver.
+        """
         return pulumi.get(self, "http_webroot_challenge")
 
     @http_webroot_challenge.setter
@@ -157,6 +294,13 @@ class CertificateArgs:
     @property
     @pulumi.getter(name="keyType")
     def key_type(self) -> Optional[pulumi.Input[str]]:
+        """
+        The key type for the certificate's private key. Can be one of:
+        `P256` and `P384` (for ECDSA keys of respective length) or `2048`, `4096`, and
+        `8192` (for RSA keys of respective length). Required when not specifying a
+        CSR. The default is `2048` (RSA key of 2048 bits). Forces a new resource when
+        changed.
+        """
         return pulumi.get(self, "key_type")
 
     @key_type.setter
@@ -166,6 +310,12 @@ class CertificateArgs:
     @property
     @pulumi.getter(name="minDaysRemaining")
     def min_days_remaining(self) -> Optional[pulumi.Input[int]]:
+        """
+        The minimum amount of days remaining on the
+        expiration of a certificate before a renewal is attempted. The default is
+        `30`. A value of less than `0` means that the certificate will never be
+        renewed.
+        """
         return pulumi.get(self, "min_days_remaining")
 
     @min_days_remaining.setter
@@ -175,6 +325,22 @@ class CertificateArgs:
     @property
     @pulumi.getter(name="mustStaple")
     def must_staple(self) -> Optional[pulumi.Input[bool]]:
+        """
+        Enables the [OCSP Stapling Required][ocsp-stapling]
+        TLS Security Policy extension. Certificates with this extension must include a
+        valid OCSP Staple in the TLS handshake for the connection to succeed.
+        Defaults to `false`. Note that this option has no effect when using an
+        external CSR - it must be enabled in the CSR itself. Forces a new resource
+        when changed.
+
+        [ocsp-stapling]: https://letsencrypt.org/docs/integration-guide/#implement-ocsp-stapling
+
+        > OCSP stapling requires specific webserver configuration to support the
+        downloading of the staple from the CA's OCSP endpoints, and should be configured
+        to tolerate prolonged outages of the OCSP service. Consider this when using
+        `must_staple`, and only enable it if you are sure your webserver or service
+        provider can be configured correctly.
+        """
         return pulumi.get(self, "must_staple")
 
     @must_staple.setter
@@ -184,6 +350,17 @@ class CertificateArgs:
     @property
     @pulumi.getter(name="preCheckDelay")
     def pre_check_delay(self) -> Optional[pulumi.Input[int]]:
+        """
+        Insert a delay after _every_ DNS challenge
+        record to allow for extra time for DNS propagation before the certificate is
+        requested. Use this option if you observe issues with requesting certificates
+        even when DNS challenge records get added successfully. Units are in seconds.
+        Defaults to 0 (no delay).
+
+        > Be careful with `pre_check_delay` since the delay is executed _per-domain_.
+        Take your expected delay and divide it by the number of domains you have
+        configured (`common_name` + `subject_alternative_names`).
+        """
         return pulumi.get(self, "pre_check_delay")
 
     @pre_check_delay.setter
@@ -193,6 +370,22 @@ class CertificateArgs:
     @property
     @pulumi.getter(name="preferredChain")
     def preferred_chain(self) -> Optional[pulumi.Input[str]]:
+        """
+        The common name of the root of a preferred
+        alternate certificate chain offered by the CA. The certificates in
+        `issuer_pem` will reflect the chain requested, if available, otherwise the
+        default chain will be provided. Forces a new resource when changed.
+
+        > `preferred_chain` can be used to request alternate chains on Let's Encrypt
+        during the transition away from their old cross-signed intermediates. See [this
+        article for more
+        details](https://letsencrypt.org/2020/12/21/extending-android-compatibility.html).
+        In their example titled **"What about the alternate chain?"**, the root you
+        would put in to the `preferred_chain` field would be `ISRG Root X1`. The
+        equivalent in the [staging
+        environment](https://letsencrypt.org/docs/staging-environment/) is `(STAGING)
+        Pretend Pear X1`.
+        """
         return pulumi.get(self, "preferred_chain")
 
     @preferred_chain.setter
@@ -202,6 +395,11 @@ class CertificateArgs:
     @property
     @pulumi.getter(name="recursiveNameservers")
     def recursive_nameservers(self) -> Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]:
+        """
+        The recursive nameservers that will be
+        used to check for propagation of DNS challenge records. Defaults to your
+        system-configured DNS resolvers.
+        """
         return pulumi.get(self, "recursive_nameservers")
 
     @recursive_nameservers.setter
@@ -211,6 +409,10 @@ class CertificateArgs:
     @property
     @pulumi.getter(name="revokeCertificateOnDestroy")
     def revoke_certificate_on_destroy(self) -> Optional[pulumi.Input[bool]]:
+        """
+        Enables revocation of a certificate upon destroy,
+        which includes when a resource is re-created. Default is `true`.
+        """
         return pulumi.get(self, "revoke_certificate_on_destroy")
 
     @revoke_certificate_on_destroy.setter
@@ -220,6 +422,11 @@ class CertificateArgs:
     @property
     @pulumi.getter(name="subjectAlternativeNames")
     def subject_alternative_names(self) -> Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]:
+        """
+        The certificate's subject alternative names,
+        domains that this certificate will also be recognized for. Only valid when not
+        specifying a CSR. Forces a new resource when changed.
+        """
         return pulumi.get(self, "subject_alternative_names")
 
     @subject_alternative_names.setter
@@ -229,6 +436,15 @@ class CertificateArgs:
     @property
     @pulumi.getter(name="tlsChallenge")
     def tls_challenge(self) -> Optional[pulumi.Input['CertificateTlsChallengeArgs']]:
+        """
+        Defines a TLS challenge to use in fulfilling the
+        request.
+
+        > Only one of `http_challenge`, `http_webroot_challenge`, and
+        `http_memcached_challenge` can be defined at once. See the section on Using
+        HTTP and TLS challenges for more details on
+        using these and `tls_challenge`.
+        """
         return pulumi.get(self, "tls_challenge")
 
     @tls_challenge.setter
@@ -266,6 +482,115 @@ class _CertificateState:
                  tls_challenge: Optional[pulumi.Input['CertificateTlsChallengeArgs']] = None):
         """
         Input properties used for looking up and filtering Certificate resources.
+        :param pulumi.Input[str] account_key_pem: The private key of the account that is
+               requesting the certificate. Forces a new resource when changed.
+        :param pulumi.Input[str] certificate_domain: The common name of the certificate.
+        :param pulumi.Input[str] certificate_not_after: The expiry date of the certificate, laid out in
+               RFC3339 format (`2006-01-02T15:04:05Z07:00`).
+        :param pulumi.Input[str] certificate_p12: The certificate, any intermediates, and the private key
+               archived as a PFX file (PKCS12 format, generally used by Microsoft products).
+               The data is base64 encoded (including padding), and its password is
+               configurable via the `certificate_p12_password`
+               argument. This field is empty if creating a certificate from a CSR.
+        :param pulumi.Input[str] certificate_p12_password: Password to be used when generating
+               the PFX file stored in `certificate_p12`. Defaults to an
+               empty string.
+        :param pulumi.Input[str] certificate_pem: The certificate in PEM format. This does not include the
+               `issuer_pem`. This certificate can be concatenated with `issuer_pem` to form
+               a full chain, e.g. `"${acme_certificate.certificate.certificate_pem}${acme_certificate.certificate.issuer_pem}"`
+        :param pulumi.Input[str] certificate_request_pem: A pre-created certificate request, such as one
+               from [`tls_cert_request`][tls-cert-request], or one from an external source,
+               in PEM format.  Either this, or the in-resource request options
+               (`common_name`, `key_type`, and optionally `subject_alternative_names`) need
+               to be specified. Forces a new resource when changed.
+        :param pulumi.Input[str] certificate_url: The full URL of the certificate within the ACME CA.
+        :param pulumi.Input[str] common_name: The certificate's common name, the primary domain that the
+               certificate will be recognized for. Required when not specifying a CSR. Forces
+               a new resource when changed.
+        :param pulumi.Input[bool] disable_complete_propagation: Disable the requirement for full
+               propagation of the TXT challenge records before proceeding with validation.
+               Defaults to `false`.
+               
+               > See About DNS propagation checks for details
+               on the `recursive_nameservers` and `disable_complete_propagation` settings.
+        :param pulumi.Input[Sequence[pulumi.Input['CertificateDnsChallengeArgs']]] dns_challenges: The DNS challenges to
+               use in fulfilling the request.
+        :param pulumi.Input['CertificateHttpChallengeArgs'] http_challenge: Defines an HTTP challenge to use in fulfilling
+               the request.
+        :param pulumi.Input['CertificateHttpMemcachedChallengeArgs'] http_memcached_challenge: Defines an alternate type of HTTP
+               challenge that can be used to serve up challenges to a
+               [Memcached](https://memcached.org/) cluster.
+        :param pulumi.Input['CertificateHttpWebrootChallengeArgs'] http_webroot_challenge: Defines an alternate type of HTTP
+               challenge that can be used to place a file at a location that can be served by
+               an out-of-band webserver.
+        :param pulumi.Input[str] issuer_pem: The intermediate certificates of the issuer. Multiple
+               certificates are concatenated in this field when there is more than one
+               intermediate certificate in the chain.
+        :param pulumi.Input[str] key_type: The key type for the certificate's private key. Can be one of:
+               `P256` and `P384` (for ECDSA keys of respective length) or `2048`, `4096`, and
+               `8192` (for RSA keys of respective length). Required when not specifying a
+               CSR. The default is `2048` (RSA key of 2048 bits). Forces a new resource when
+               changed.
+        :param pulumi.Input[int] min_days_remaining: The minimum amount of days remaining on the
+               expiration of a certificate before a renewal is attempted. The default is
+               `30`. A value of less than `0` means that the certificate will never be
+               renewed.
+        :param pulumi.Input[bool] must_staple: Enables the [OCSP Stapling Required][ocsp-stapling]
+               TLS Security Policy extension. Certificates with this extension must include a
+               valid OCSP Staple in the TLS handshake for the connection to succeed.
+               Defaults to `false`. Note that this option has no effect when using an
+               external CSR - it must be enabled in the CSR itself. Forces a new resource
+               when changed.
+               
+               [ocsp-stapling]: https://letsencrypt.org/docs/integration-guide/#implement-ocsp-stapling
+               
+               > OCSP stapling requires specific webserver configuration to support the
+               downloading of the staple from the CA's OCSP endpoints, and should be configured
+               to tolerate prolonged outages of the OCSP service. Consider this when using
+               `must_staple`, and only enable it if you are sure your webserver or service
+               provider can be configured correctly.
+        :param pulumi.Input[int] pre_check_delay: Insert a delay after _every_ DNS challenge
+               record to allow for extra time for DNS propagation before the certificate is
+               requested. Use this option if you observe issues with requesting certificates
+               even when DNS challenge records get added successfully. Units are in seconds.
+               Defaults to 0 (no delay).
+               
+               > Be careful with `pre_check_delay` since the delay is executed _per-domain_.
+               Take your expected delay and divide it by the number of domains you have
+               configured (`common_name` + `subject_alternative_names`).
+        :param pulumi.Input[str] preferred_chain: The common name of the root of a preferred
+               alternate certificate chain offered by the CA. The certificates in
+               `issuer_pem` will reflect the chain requested, if available, otherwise the
+               default chain will be provided. Forces a new resource when changed.
+               
+               > `preferred_chain` can be used to request alternate chains on Let's Encrypt
+               during the transition away from their old cross-signed intermediates. See [this
+               article for more
+               details](https://letsencrypt.org/2020/12/21/extending-android-compatibility.html).
+               In their example titled **"What about the alternate chain?"**, the root you
+               would put in to the `preferred_chain` field would be `ISRG Root X1`. The
+               equivalent in the [staging
+               environment](https://letsencrypt.org/docs/staging-environment/) is `(STAGING)
+               Pretend Pear X1`.
+        :param pulumi.Input[str] private_key_pem: The certificate's private key, in PEM format, if the
+               certificate was generated from scratch and not with
+               `certificate_request_pem`.  If
+               `certificate_request_pem` was used, this will be blank.
+        :param pulumi.Input[Sequence[pulumi.Input[str]]] recursive_nameservers: The recursive nameservers that will be
+               used to check for propagation of DNS challenge records. Defaults to your
+               system-configured DNS resolvers.
+        :param pulumi.Input[bool] revoke_certificate_on_destroy: Enables revocation of a certificate upon destroy,
+               which includes when a resource is re-created. Default is `true`.
+        :param pulumi.Input[Sequence[pulumi.Input[str]]] subject_alternative_names: The certificate's subject alternative names,
+               domains that this certificate will also be recognized for. Only valid when not
+               specifying a CSR. Forces a new resource when changed.
+        :param pulumi.Input['CertificateTlsChallengeArgs'] tls_challenge: Defines a TLS challenge to use in fulfilling the
+               request.
+               
+               > Only one of `http_challenge`, `http_webroot_challenge`, and
+               `http_memcached_challenge` can be defined at once. See the section on Using
+               HTTP and TLS challenges for more details on
+               using these and `tls_challenge`.
         """
         if account_key_pem is not None:
             pulumi.set(__self__, "account_key_pem", account_key_pem)
@@ -321,6 +646,10 @@ class _CertificateState:
     @property
     @pulumi.getter(name="accountKeyPem")
     def account_key_pem(self) -> Optional[pulumi.Input[str]]:
+        """
+        The private key of the account that is
+        requesting the certificate. Forces a new resource when changed.
+        """
         return pulumi.get(self, "account_key_pem")
 
     @account_key_pem.setter
@@ -330,6 +659,9 @@ class _CertificateState:
     @property
     @pulumi.getter(name="certificateDomain")
     def certificate_domain(self) -> Optional[pulumi.Input[str]]:
+        """
+        The common name of the certificate.
+        """
         return pulumi.get(self, "certificate_domain")
 
     @certificate_domain.setter
@@ -339,6 +671,10 @@ class _CertificateState:
     @property
     @pulumi.getter(name="certificateNotAfter")
     def certificate_not_after(self) -> Optional[pulumi.Input[str]]:
+        """
+        The expiry date of the certificate, laid out in
+        RFC3339 format (`2006-01-02T15:04:05Z07:00`).
+        """
         return pulumi.get(self, "certificate_not_after")
 
     @certificate_not_after.setter
@@ -348,6 +684,13 @@ class _CertificateState:
     @property
     @pulumi.getter(name="certificateP12")
     def certificate_p12(self) -> Optional[pulumi.Input[str]]:
+        """
+        The certificate, any intermediates, and the private key
+        archived as a PFX file (PKCS12 format, generally used by Microsoft products).
+        The data is base64 encoded (including padding), and its password is
+        configurable via the `certificate_p12_password`
+        argument. This field is empty if creating a certificate from a CSR.
+        """
         return pulumi.get(self, "certificate_p12")
 
     @certificate_p12.setter
@@ -357,6 +700,11 @@ class _CertificateState:
     @property
     @pulumi.getter(name="certificateP12Password")
     def certificate_p12_password(self) -> Optional[pulumi.Input[str]]:
+        """
+        Password to be used when generating
+        the PFX file stored in `certificate_p12`. Defaults to an
+        empty string.
+        """
         return pulumi.get(self, "certificate_p12_password")
 
     @certificate_p12_password.setter
@@ -366,6 +714,11 @@ class _CertificateState:
     @property
     @pulumi.getter(name="certificatePem")
     def certificate_pem(self) -> Optional[pulumi.Input[str]]:
+        """
+        The certificate in PEM format. This does not include the
+        `issuer_pem`. This certificate can be concatenated with `issuer_pem` to form
+        a full chain, e.g. `"${acme_certificate.certificate.certificate_pem}${acme_certificate.certificate.issuer_pem}"`
+        """
         return pulumi.get(self, "certificate_pem")
 
     @certificate_pem.setter
@@ -375,6 +728,13 @@ class _CertificateState:
     @property
     @pulumi.getter(name="certificateRequestPem")
     def certificate_request_pem(self) -> Optional[pulumi.Input[str]]:
+        """
+        A pre-created certificate request, such as one
+        from [`tls_cert_request`][tls-cert-request], or one from an external source,
+        in PEM format.  Either this, or the in-resource request options
+        (`common_name`, `key_type`, and optionally `subject_alternative_names`) need
+        to be specified. Forces a new resource when changed.
+        """
         return pulumi.get(self, "certificate_request_pem")
 
     @certificate_request_pem.setter
@@ -384,6 +744,9 @@ class _CertificateState:
     @property
     @pulumi.getter(name="certificateUrl")
     def certificate_url(self) -> Optional[pulumi.Input[str]]:
+        """
+        The full URL of the certificate within the ACME CA.
+        """
         return pulumi.get(self, "certificate_url")
 
     @certificate_url.setter
@@ -393,6 +756,11 @@ class _CertificateState:
     @property
     @pulumi.getter(name="commonName")
     def common_name(self) -> Optional[pulumi.Input[str]]:
+        """
+        The certificate's common name, the primary domain that the
+        certificate will be recognized for. Required when not specifying a CSR. Forces
+        a new resource when changed.
+        """
         return pulumi.get(self, "common_name")
 
     @common_name.setter
@@ -402,6 +770,14 @@ class _CertificateState:
     @property
     @pulumi.getter(name="disableCompletePropagation")
     def disable_complete_propagation(self) -> Optional[pulumi.Input[bool]]:
+        """
+        Disable the requirement for full
+        propagation of the TXT challenge records before proceeding with validation.
+        Defaults to `false`.
+
+        > See About DNS propagation checks for details
+        on the `recursive_nameservers` and `disable_complete_propagation` settings.
+        """
         return pulumi.get(self, "disable_complete_propagation")
 
     @disable_complete_propagation.setter
@@ -411,6 +787,10 @@ class _CertificateState:
     @property
     @pulumi.getter(name="dnsChallenges")
     def dns_challenges(self) -> Optional[pulumi.Input[Sequence[pulumi.Input['CertificateDnsChallengeArgs']]]]:
+        """
+        The DNS challenges to
+        use in fulfilling the request.
+        """
         return pulumi.get(self, "dns_challenges")
 
     @dns_challenges.setter
@@ -420,6 +800,10 @@ class _CertificateState:
     @property
     @pulumi.getter(name="httpChallenge")
     def http_challenge(self) -> Optional[pulumi.Input['CertificateHttpChallengeArgs']]:
+        """
+        Defines an HTTP challenge to use in fulfilling
+        the request.
+        """
         return pulumi.get(self, "http_challenge")
 
     @http_challenge.setter
@@ -429,6 +813,11 @@ class _CertificateState:
     @property
     @pulumi.getter(name="httpMemcachedChallenge")
     def http_memcached_challenge(self) -> Optional[pulumi.Input['CertificateHttpMemcachedChallengeArgs']]:
+        """
+        Defines an alternate type of HTTP
+        challenge that can be used to serve up challenges to a
+        [Memcached](https://memcached.org/) cluster.
+        """
         return pulumi.get(self, "http_memcached_challenge")
 
     @http_memcached_challenge.setter
@@ -438,6 +827,11 @@ class _CertificateState:
     @property
     @pulumi.getter(name="httpWebrootChallenge")
     def http_webroot_challenge(self) -> Optional[pulumi.Input['CertificateHttpWebrootChallengeArgs']]:
+        """
+        Defines an alternate type of HTTP
+        challenge that can be used to place a file at a location that can be served by
+        an out-of-band webserver.
+        """
         return pulumi.get(self, "http_webroot_challenge")
 
     @http_webroot_challenge.setter
@@ -447,6 +841,11 @@ class _CertificateState:
     @property
     @pulumi.getter(name="issuerPem")
     def issuer_pem(self) -> Optional[pulumi.Input[str]]:
+        """
+        The intermediate certificates of the issuer. Multiple
+        certificates are concatenated in this field when there is more than one
+        intermediate certificate in the chain.
+        """
         return pulumi.get(self, "issuer_pem")
 
     @issuer_pem.setter
@@ -456,6 +855,13 @@ class _CertificateState:
     @property
     @pulumi.getter(name="keyType")
     def key_type(self) -> Optional[pulumi.Input[str]]:
+        """
+        The key type for the certificate's private key. Can be one of:
+        `P256` and `P384` (for ECDSA keys of respective length) or `2048`, `4096`, and
+        `8192` (for RSA keys of respective length). Required when not specifying a
+        CSR. The default is `2048` (RSA key of 2048 bits). Forces a new resource when
+        changed.
+        """
         return pulumi.get(self, "key_type")
 
     @key_type.setter
@@ -465,6 +871,12 @@ class _CertificateState:
     @property
     @pulumi.getter(name="minDaysRemaining")
     def min_days_remaining(self) -> Optional[pulumi.Input[int]]:
+        """
+        The minimum amount of days remaining on the
+        expiration of a certificate before a renewal is attempted. The default is
+        `30`. A value of less than `0` means that the certificate will never be
+        renewed.
+        """
         return pulumi.get(self, "min_days_remaining")
 
     @min_days_remaining.setter
@@ -474,6 +886,22 @@ class _CertificateState:
     @property
     @pulumi.getter(name="mustStaple")
     def must_staple(self) -> Optional[pulumi.Input[bool]]:
+        """
+        Enables the [OCSP Stapling Required][ocsp-stapling]
+        TLS Security Policy extension. Certificates with this extension must include a
+        valid OCSP Staple in the TLS handshake for the connection to succeed.
+        Defaults to `false`. Note that this option has no effect when using an
+        external CSR - it must be enabled in the CSR itself. Forces a new resource
+        when changed.
+
+        [ocsp-stapling]: https://letsencrypt.org/docs/integration-guide/#implement-ocsp-stapling
+
+        > OCSP stapling requires specific webserver configuration to support the
+        downloading of the staple from the CA's OCSP endpoints, and should be configured
+        to tolerate prolonged outages of the OCSP service. Consider this when using
+        `must_staple`, and only enable it if you are sure your webserver or service
+        provider can be configured correctly.
+        """
         return pulumi.get(self, "must_staple")
 
     @must_staple.setter
@@ -483,6 +911,17 @@ class _CertificateState:
     @property
     @pulumi.getter(name="preCheckDelay")
     def pre_check_delay(self) -> Optional[pulumi.Input[int]]:
+        """
+        Insert a delay after _every_ DNS challenge
+        record to allow for extra time for DNS propagation before the certificate is
+        requested. Use this option if you observe issues with requesting certificates
+        even when DNS challenge records get added successfully. Units are in seconds.
+        Defaults to 0 (no delay).
+
+        > Be careful with `pre_check_delay` since the delay is executed _per-domain_.
+        Take your expected delay and divide it by the number of domains you have
+        configured (`common_name` + `subject_alternative_names`).
+        """
         return pulumi.get(self, "pre_check_delay")
 
     @pre_check_delay.setter
@@ -492,6 +931,22 @@ class _CertificateState:
     @property
     @pulumi.getter(name="preferredChain")
     def preferred_chain(self) -> Optional[pulumi.Input[str]]:
+        """
+        The common name of the root of a preferred
+        alternate certificate chain offered by the CA. The certificates in
+        `issuer_pem` will reflect the chain requested, if available, otherwise the
+        default chain will be provided. Forces a new resource when changed.
+
+        > `preferred_chain` can be used to request alternate chains on Let's Encrypt
+        during the transition away from their old cross-signed intermediates. See [this
+        article for more
+        details](https://letsencrypt.org/2020/12/21/extending-android-compatibility.html).
+        In their example titled **"What about the alternate chain?"**, the root you
+        would put in to the `preferred_chain` field would be `ISRG Root X1`. The
+        equivalent in the [staging
+        environment](https://letsencrypt.org/docs/staging-environment/) is `(STAGING)
+        Pretend Pear X1`.
+        """
         return pulumi.get(self, "preferred_chain")
 
     @preferred_chain.setter
@@ -501,6 +956,12 @@ class _CertificateState:
     @property
     @pulumi.getter(name="privateKeyPem")
     def private_key_pem(self) -> Optional[pulumi.Input[str]]:
+        """
+        The certificate's private key, in PEM format, if the
+        certificate was generated from scratch and not with
+        `certificate_request_pem`.  If
+        `certificate_request_pem` was used, this will be blank.
+        """
         return pulumi.get(self, "private_key_pem")
 
     @private_key_pem.setter
@@ -510,6 +971,11 @@ class _CertificateState:
     @property
     @pulumi.getter(name="recursiveNameservers")
     def recursive_nameservers(self) -> Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]:
+        """
+        The recursive nameservers that will be
+        used to check for propagation of DNS challenge records. Defaults to your
+        system-configured DNS resolvers.
+        """
         return pulumi.get(self, "recursive_nameservers")
 
     @recursive_nameservers.setter
@@ -519,6 +985,10 @@ class _CertificateState:
     @property
     @pulumi.getter(name="revokeCertificateOnDestroy")
     def revoke_certificate_on_destroy(self) -> Optional[pulumi.Input[bool]]:
+        """
+        Enables revocation of a certificate upon destroy,
+        which includes when a resource is re-created. Default is `true`.
+        """
         return pulumi.get(self, "revoke_certificate_on_destroy")
 
     @revoke_certificate_on_destroy.setter
@@ -528,6 +998,11 @@ class _CertificateState:
     @property
     @pulumi.getter(name="subjectAlternativeNames")
     def subject_alternative_names(self) -> Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]:
+        """
+        The certificate's subject alternative names,
+        domains that this certificate will also be recognized for. Only valid when not
+        specifying a CSR. Forces a new resource when changed.
+        """
         return pulumi.get(self, "subject_alternative_names")
 
     @subject_alternative_names.setter
@@ -537,6 +1012,15 @@ class _CertificateState:
     @property
     @pulumi.getter(name="tlsChallenge")
     def tls_challenge(self) -> Optional[pulumi.Input['CertificateTlsChallengeArgs']]:
+        """
+        Defines a TLS challenge to use in fulfilling the
+        request.
+
+        > Only one of `http_challenge`, `http_webroot_challenge`, and
+        `http_memcached_challenge` can be defined at once. See the section on Using
+        HTTP and TLS challenges for more details on
+        using these and `tls_challenge`.
+        """
         return pulumi.get(self, "tls_challenge")
 
     @tls_challenge.setter
@@ -572,6 +1056,96 @@ class Certificate(pulumi.CustomResource):
         Create a Certificate resource with the given unique name, props, and options.
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
+        :param pulumi.Input[str] account_key_pem: The private key of the account that is
+               requesting the certificate. Forces a new resource when changed.
+        :param pulumi.Input[str] certificate_p12_password: Password to be used when generating
+               the PFX file stored in `certificate_p12`. Defaults to an
+               empty string.
+        :param pulumi.Input[str] certificate_request_pem: A pre-created certificate request, such as one
+               from [`tls_cert_request`][tls-cert-request], or one from an external source,
+               in PEM format.  Either this, or the in-resource request options
+               (`common_name`, `key_type`, and optionally `subject_alternative_names`) need
+               to be specified. Forces a new resource when changed.
+        :param pulumi.Input[str] common_name: The certificate's common name, the primary domain that the
+               certificate will be recognized for. Required when not specifying a CSR. Forces
+               a new resource when changed.
+        :param pulumi.Input[bool] disable_complete_propagation: Disable the requirement for full
+               propagation of the TXT challenge records before proceeding with validation.
+               Defaults to `false`.
+               
+               > See About DNS propagation checks for details
+               on the `recursive_nameservers` and `disable_complete_propagation` settings.
+        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['CertificateDnsChallengeArgs']]]] dns_challenges: The DNS challenges to
+               use in fulfilling the request.
+        :param pulumi.Input[pulumi.InputType['CertificateHttpChallengeArgs']] http_challenge: Defines an HTTP challenge to use in fulfilling
+               the request.
+        :param pulumi.Input[pulumi.InputType['CertificateHttpMemcachedChallengeArgs']] http_memcached_challenge: Defines an alternate type of HTTP
+               challenge that can be used to serve up challenges to a
+               [Memcached](https://memcached.org/) cluster.
+        :param pulumi.Input[pulumi.InputType['CertificateHttpWebrootChallengeArgs']] http_webroot_challenge: Defines an alternate type of HTTP
+               challenge that can be used to place a file at a location that can be served by
+               an out-of-band webserver.
+        :param pulumi.Input[str] key_type: The key type for the certificate's private key. Can be one of:
+               `P256` and `P384` (for ECDSA keys of respective length) or `2048`, `4096`, and
+               `8192` (for RSA keys of respective length). Required when not specifying a
+               CSR. The default is `2048` (RSA key of 2048 bits). Forces a new resource when
+               changed.
+        :param pulumi.Input[int] min_days_remaining: The minimum amount of days remaining on the
+               expiration of a certificate before a renewal is attempted. The default is
+               `30`. A value of less than `0` means that the certificate will never be
+               renewed.
+        :param pulumi.Input[bool] must_staple: Enables the [OCSP Stapling Required][ocsp-stapling]
+               TLS Security Policy extension. Certificates with this extension must include a
+               valid OCSP Staple in the TLS handshake for the connection to succeed.
+               Defaults to `false`. Note that this option has no effect when using an
+               external CSR - it must be enabled in the CSR itself. Forces a new resource
+               when changed.
+               
+               [ocsp-stapling]: https://letsencrypt.org/docs/integration-guide/#implement-ocsp-stapling
+               
+               > OCSP stapling requires specific webserver configuration to support the
+               downloading of the staple from the CA's OCSP endpoints, and should be configured
+               to tolerate prolonged outages of the OCSP service. Consider this when using
+               `must_staple`, and only enable it if you are sure your webserver or service
+               provider can be configured correctly.
+        :param pulumi.Input[int] pre_check_delay: Insert a delay after _every_ DNS challenge
+               record to allow for extra time for DNS propagation before the certificate is
+               requested. Use this option if you observe issues with requesting certificates
+               even when DNS challenge records get added successfully. Units are in seconds.
+               Defaults to 0 (no delay).
+               
+               > Be careful with `pre_check_delay` since the delay is executed _per-domain_.
+               Take your expected delay and divide it by the number of domains you have
+               configured (`common_name` + `subject_alternative_names`).
+        :param pulumi.Input[str] preferred_chain: The common name of the root of a preferred
+               alternate certificate chain offered by the CA. The certificates in
+               `issuer_pem` will reflect the chain requested, if available, otherwise the
+               default chain will be provided. Forces a new resource when changed.
+               
+               > `preferred_chain` can be used to request alternate chains on Let's Encrypt
+               during the transition away from their old cross-signed intermediates. See [this
+               article for more
+               details](https://letsencrypt.org/2020/12/21/extending-android-compatibility.html).
+               In their example titled **"What about the alternate chain?"**, the root you
+               would put in to the `preferred_chain` field would be `ISRG Root X1`. The
+               equivalent in the [staging
+               environment](https://letsencrypt.org/docs/staging-environment/) is `(STAGING)
+               Pretend Pear X1`.
+        :param pulumi.Input[Sequence[pulumi.Input[str]]] recursive_nameservers: The recursive nameservers that will be
+               used to check for propagation of DNS challenge records. Defaults to your
+               system-configured DNS resolvers.
+        :param pulumi.Input[bool] revoke_certificate_on_destroy: Enables revocation of a certificate upon destroy,
+               which includes when a resource is re-created. Default is `true`.
+        :param pulumi.Input[Sequence[pulumi.Input[str]]] subject_alternative_names: The certificate's subject alternative names,
+               domains that this certificate will also be recognized for. Only valid when not
+               specifying a CSR. Forces a new resource when changed.
+        :param pulumi.Input[pulumi.InputType['CertificateTlsChallengeArgs']] tls_challenge: Defines a TLS challenge to use in fulfilling the
+               request.
+               
+               > Only one of `http_challenge`, `http_webroot_challenge`, and
+               `http_memcached_challenge` can be defined at once. See the section on Using
+               HTTP and TLS challenges for more details on
+               using these and `tls_challenge`.
         """
         ...
     @overload
@@ -694,6 +1268,115 @@ class Certificate(pulumi.CustomResource):
         :param str resource_name: The unique name of the resulting resource.
         :param pulumi.Input[str] id: The unique provider ID of the resource to lookup.
         :param pulumi.ResourceOptions opts: Options for the resource.
+        :param pulumi.Input[str] account_key_pem: The private key of the account that is
+               requesting the certificate. Forces a new resource when changed.
+        :param pulumi.Input[str] certificate_domain: The common name of the certificate.
+        :param pulumi.Input[str] certificate_not_after: The expiry date of the certificate, laid out in
+               RFC3339 format (`2006-01-02T15:04:05Z07:00`).
+        :param pulumi.Input[str] certificate_p12: The certificate, any intermediates, and the private key
+               archived as a PFX file (PKCS12 format, generally used by Microsoft products).
+               The data is base64 encoded (including padding), and its password is
+               configurable via the `certificate_p12_password`
+               argument. This field is empty if creating a certificate from a CSR.
+        :param pulumi.Input[str] certificate_p12_password: Password to be used when generating
+               the PFX file stored in `certificate_p12`. Defaults to an
+               empty string.
+        :param pulumi.Input[str] certificate_pem: The certificate in PEM format. This does not include the
+               `issuer_pem`. This certificate can be concatenated with `issuer_pem` to form
+               a full chain, e.g. `"${acme_certificate.certificate.certificate_pem}${acme_certificate.certificate.issuer_pem}"`
+        :param pulumi.Input[str] certificate_request_pem: A pre-created certificate request, such as one
+               from [`tls_cert_request`][tls-cert-request], or one from an external source,
+               in PEM format.  Either this, or the in-resource request options
+               (`common_name`, `key_type`, and optionally `subject_alternative_names`) need
+               to be specified. Forces a new resource when changed.
+        :param pulumi.Input[str] certificate_url: The full URL of the certificate within the ACME CA.
+        :param pulumi.Input[str] common_name: The certificate's common name, the primary domain that the
+               certificate will be recognized for. Required when not specifying a CSR. Forces
+               a new resource when changed.
+        :param pulumi.Input[bool] disable_complete_propagation: Disable the requirement for full
+               propagation of the TXT challenge records before proceeding with validation.
+               Defaults to `false`.
+               
+               > See About DNS propagation checks for details
+               on the `recursive_nameservers` and `disable_complete_propagation` settings.
+        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['CertificateDnsChallengeArgs']]]] dns_challenges: The DNS challenges to
+               use in fulfilling the request.
+        :param pulumi.Input[pulumi.InputType['CertificateHttpChallengeArgs']] http_challenge: Defines an HTTP challenge to use in fulfilling
+               the request.
+        :param pulumi.Input[pulumi.InputType['CertificateHttpMemcachedChallengeArgs']] http_memcached_challenge: Defines an alternate type of HTTP
+               challenge that can be used to serve up challenges to a
+               [Memcached](https://memcached.org/) cluster.
+        :param pulumi.Input[pulumi.InputType['CertificateHttpWebrootChallengeArgs']] http_webroot_challenge: Defines an alternate type of HTTP
+               challenge that can be used to place a file at a location that can be served by
+               an out-of-band webserver.
+        :param pulumi.Input[str] issuer_pem: The intermediate certificates of the issuer. Multiple
+               certificates are concatenated in this field when there is more than one
+               intermediate certificate in the chain.
+        :param pulumi.Input[str] key_type: The key type for the certificate's private key. Can be one of:
+               `P256` and `P384` (for ECDSA keys of respective length) or `2048`, `4096`, and
+               `8192` (for RSA keys of respective length). Required when not specifying a
+               CSR. The default is `2048` (RSA key of 2048 bits). Forces a new resource when
+               changed.
+        :param pulumi.Input[int] min_days_remaining: The minimum amount of days remaining on the
+               expiration of a certificate before a renewal is attempted. The default is
+               `30`. A value of less than `0` means that the certificate will never be
+               renewed.
+        :param pulumi.Input[bool] must_staple: Enables the [OCSP Stapling Required][ocsp-stapling]
+               TLS Security Policy extension. Certificates with this extension must include a
+               valid OCSP Staple in the TLS handshake for the connection to succeed.
+               Defaults to `false`. Note that this option has no effect when using an
+               external CSR - it must be enabled in the CSR itself. Forces a new resource
+               when changed.
+               
+               [ocsp-stapling]: https://letsencrypt.org/docs/integration-guide/#implement-ocsp-stapling
+               
+               > OCSP stapling requires specific webserver configuration to support the
+               downloading of the staple from the CA's OCSP endpoints, and should be configured
+               to tolerate prolonged outages of the OCSP service. Consider this when using
+               `must_staple`, and only enable it if you are sure your webserver or service
+               provider can be configured correctly.
+        :param pulumi.Input[int] pre_check_delay: Insert a delay after _every_ DNS challenge
+               record to allow for extra time for DNS propagation before the certificate is
+               requested. Use this option if you observe issues with requesting certificates
+               even when DNS challenge records get added successfully. Units are in seconds.
+               Defaults to 0 (no delay).
+               
+               > Be careful with `pre_check_delay` since the delay is executed _per-domain_.
+               Take your expected delay and divide it by the number of domains you have
+               configured (`common_name` + `subject_alternative_names`).
+        :param pulumi.Input[str] preferred_chain: The common name of the root of a preferred
+               alternate certificate chain offered by the CA. The certificates in
+               `issuer_pem` will reflect the chain requested, if available, otherwise the
+               default chain will be provided. Forces a new resource when changed.
+               
+               > `preferred_chain` can be used to request alternate chains on Let's Encrypt
+               during the transition away from their old cross-signed intermediates. See [this
+               article for more
+               details](https://letsencrypt.org/2020/12/21/extending-android-compatibility.html).
+               In their example titled **"What about the alternate chain?"**, the root you
+               would put in to the `preferred_chain` field would be `ISRG Root X1`. The
+               equivalent in the [staging
+               environment](https://letsencrypt.org/docs/staging-environment/) is `(STAGING)
+               Pretend Pear X1`.
+        :param pulumi.Input[str] private_key_pem: The certificate's private key, in PEM format, if the
+               certificate was generated from scratch and not with
+               `certificate_request_pem`.  If
+               `certificate_request_pem` was used, this will be blank.
+        :param pulumi.Input[Sequence[pulumi.Input[str]]] recursive_nameservers: The recursive nameservers that will be
+               used to check for propagation of DNS challenge records. Defaults to your
+               system-configured DNS resolvers.
+        :param pulumi.Input[bool] revoke_certificate_on_destroy: Enables revocation of a certificate upon destroy,
+               which includes when a resource is re-created. Default is `true`.
+        :param pulumi.Input[Sequence[pulumi.Input[str]]] subject_alternative_names: The certificate's subject alternative names,
+               domains that this certificate will also be recognized for. Only valid when not
+               specifying a CSR. Forces a new resource when changed.
+        :param pulumi.Input[pulumi.InputType['CertificateTlsChallengeArgs']] tls_challenge: Defines a TLS challenge to use in fulfilling the
+               request.
+               
+               > Only one of `http_challenge`, `http_webroot_challenge`, and
+               `http_memcached_challenge` can be defined at once. See the section on Using
+               HTTP and TLS challenges for more details on
+               using these and `tls_challenge`.
         """
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(id=id))
 
@@ -729,125 +1412,284 @@ class Certificate(pulumi.CustomResource):
     @property
     @pulumi.getter(name="accountKeyPem")
     def account_key_pem(self) -> pulumi.Output[str]:
+        """
+        The private key of the account that is
+        requesting the certificate. Forces a new resource when changed.
+        """
         return pulumi.get(self, "account_key_pem")
 
     @property
     @pulumi.getter(name="certificateDomain")
     def certificate_domain(self) -> pulumi.Output[str]:
+        """
+        The common name of the certificate.
+        """
         return pulumi.get(self, "certificate_domain")
 
     @property
     @pulumi.getter(name="certificateNotAfter")
     def certificate_not_after(self) -> pulumi.Output[str]:
+        """
+        The expiry date of the certificate, laid out in
+        RFC3339 format (`2006-01-02T15:04:05Z07:00`).
+        """
         return pulumi.get(self, "certificate_not_after")
 
     @property
     @pulumi.getter(name="certificateP12")
     def certificate_p12(self) -> pulumi.Output[str]:
+        """
+        The certificate, any intermediates, and the private key
+        archived as a PFX file (PKCS12 format, generally used by Microsoft products).
+        The data is base64 encoded (including padding), and its password is
+        configurable via the `certificate_p12_password`
+        argument. This field is empty if creating a certificate from a CSR.
+        """
         return pulumi.get(self, "certificate_p12")
 
     @property
     @pulumi.getter(name="certificateP12Password")
     def certificate_p12_password(self) -> pulumi.Output[Optional[str]]:
+        """
+        Password to be used when generating
+        the PFX file stored in `certificate_p12`. Defaults to an
+        empty string.
+        """
         return pulumi.get(self, "certificate_p12_password")
 
     @property
     @pulumi.getter(name="certificatePem")
     def certificate_pem(self) -> pulumi.Output[str]:
+        """
+        The certificate in PEM format. This does not include the
+        `issuer_pem`. This certificate can be concatenated with `issuer_pem` to form
+        a full chain, e.g. `"${acme_certificate.certificate.certificate_pem}${acme_certificate.certificate.issuer_pem}"`
+        """
         return pulumi.get(self, "certificate_pem")
 
     @property
     @pulumi.getter(name="certificateRequestPem")
     def certificate_request_pem(self) -> pulumi.Output[Optional[str]]:
+        """
+        A pre-created certificate request, such as one
+        from [`tls_cert_request`][tls-cert-request], or one from an external source,
+        in PEM format.  Either this, or the in-resource request options
+        (`common_name`, `key_type`, and optionally `subject_alternative_names`) need
+        to be specified. Forces a new resource when changed.
+        """
         return pulumi.get(self, "certificate_request_pem")
 
     @property
     @pulumi.getter(name="certificateUrl")
     def certificate_url(self) -> pulumi.Output[str]:
+        """
+        The full URL of the certificate within the ACME CA.
+        """
         return pulumi.get(self, "certificate_url")
 
     @property
     @pulumi.getter(name="commonName")
     def common_name(self) -> pulumi.Output[Optional[str]]:
+        """
+        The certificate's common name, the primary domain that the
+        certificate will be recognized for. Required when not specifying a CSR. Forces
+        a new resource when changed.
+        """
         return pulumi.get(self, "common_name")
 
     @property
     @pulumi.getter(name="disableCompletePropagation")
     def disable_complete_propagation(self) -> pulumi.Output[Optional[bool]]:
+        """
+        Disable the requirement for full
+        propagation of the TXT challenge records before proceeding with validation.
+        Defaults to `false`.
+
+        > See About DNS propagation checks for details
+        on the `recursive_nameservers` and `disable_complete_propagation` settings.
+        """
         return pulumi.get(self, "disable_complete_propagation")
 
     @property
     @pulumi.getter(name="dnsChallenges")
     def dns_challenges(self) -> pulumi.Output[Optional[Sequence['outputs.CertificateDnsChallenge']]]:
+        """
+        The DNS challenges to
+        use in fulfilling the request.
+        """
         return pulumi.get(self, "dns_challenges")
 
     @property
     @pulumi.getter(name="httpChallenge")
     def http_challenge(self) -> pulumi.Output[Optional['outputs.CertificateHttpChallenge']]:
+        """
+        Defines an HTTP challenge to use in fulfilling
+        the request.
+        """
         return pulumi.get(self, "http_challenge")
 
     @property
     @pulumi.getter(name="httpMemcachedChallenge")
     def http_memcached_challenge(self) -> pulumi.Output[Optional['outputs.CertificateHttpMemcachedChallenge']]:
+        """
+        Defines an alternate type of HTTP
+        challenge that can be used to serve up challenges to a
+        [Memcached](https://memcached.org/) cluster.
+        """
         return pulumi.get(self, "http_memcached_challenge")
 
     @property
     @pulumi.getter(name="httpWebrootChallenge")
     def http_webroot_challenge(self) -> pulumi.Output[Optional['outputs.CertificateHttpWebrootChallenge']]:
+        """
+        Defines an alternate type of HTTP
+        challenge that can be used to place a file at a location that can be served by
+        an out-of-band webserver.
+        """
         return pulumi.get(self, "http_webroot_challenge")
 
     @property
     @pulumi.getter(name="issuerPem")
     def issuer_pem(self) -> pulumi.Output[str]:
+        """
+        The intermediate certificates of the issuer. Multiple
+        certificates are concatenated in this field when there is more than one
+        intermediate certificate in the chain.
+        """
         return pulumi.get(self, "issuer_pem")
 
     @property
     @pulumi.getter(name="keyType")
     def key_type(self) -> pulumi.Output[Optional[str]]:
+        """
+        The key type for the certificate's private key. Can be one of:
+        `P256` and `P384` (for ECDSA keys of respective length) or `2048`, `4096`, and
+        `8192` (for RSA keys of respective length). Required when not specifying a
+        CSR. The default is `2048` (RSA key of 2048 bits). Forces a new resource when
+        changed.
+        """
         return pulumi.get(self, "key_type")
 
     @property
     @pulumi.getter(name="minDaysRemaining")
     def min_days_remaining(self) -> pulumi.Output[Optional[int]]:
+        """
+        The minimum amount of days remaining on the
+        expiration of a certificate before a renewal is attempted. The default is
+        `30`. A value of less than `0` means that the certificate will never be
+        renewed.
+        """
         return pulumi.get(self, "min_days_remaining")
 
     @property
     @pulumi.getter(name="mustStaple")
     def must_staple(self) -> pulumi.Output[Optional[bool]]:
+        """
+        Enables the [OCSP Stapling Required][ocsp-stapling]
+        TLS Security Policy extension. Certificates with this extension must include a
+        valid OCSP Staple in the TLS handshake for the connection to succeed.
+        Defaults to `false`. Note that this option has no effect when using an
+        external CSR - it must be enabled in the CSR itself. Forces a new resource
+        when changed.
+
+        [ocsp-stapling]: https://letsencrypt.org/docs/integration-guide/#implement-ocsp-stapling
+
+        > OCSP stapling requires specific webserver configuration to support the
+        downloading of the staple from the CA's OCSP endpoints, and should be configured
+        to tolerate prolonged outages of the OCSP service. Consider this when using
+        `must_staple`, and only enable it if you are sure your webserver or service
+        provider can be configured correctly.
+        """
         return pulumi.get(self, "must_staple")
 
     @property
     @pulumi.getter(name="preCheckDelay")
     def pre_check_delay(self) -> pulumi.Output[Optional[int]]:
+        """
+        Insert a delay after _every_ DNS challenge
+        record to allow for extra time for DNS propagation before the certificate is
+        requested. Use this option if you observe issues with requesting certificates
+        even when DNS challenge records get added successfully. Units are in seconds.
+        Defaults to 0 (no delay).
+
+        > Be careful with `pre_check_delay` since the delay is executed _per-domain_.
+        Take your expected delay and divide it by the number of domains you have
+        configured (`common_name` + `subject_alternative_names`).
+        """
         return pulumi.get(self, "pre_check_delay")
 
     @property
     @pulumi.getter(name="preferredChain")
     def preferred_chain(self) -> pulumi.Output[Optional[str]]:
+        """
+        The common name of the root of a preferred
+        alternate certificate chain offered by the CA. The certificates in
+        `issuer_pem` will reflect the chain requested, if available, otherwise the
+        default chain will be provided. Forces a new resource when changed.
+
+        > `preferred_chain` can be used to request alternate chains on Let's Encrypt
+        during the transition away from their old cross-signed intermediates. See [this
+        article for more
+        details](https://letsencrypt.org/2020/12/21/extending-android-compatibility.html).
+        In their example titled **"What about the alternate chain?"**, the root you
+        would put in to the `preferred_chain` field would be `ISRG Root X1`. The
+        equivalent in the [staging
+        environment](https://letsencrypt.org/docs/staging-environment/) is `(STAGING)
+        Pretend Pear X1`.
+        """
         return pulumi.get(self, "preferred_chain")
 
     @property
     @pulumi.getter(name="privateKeyPem")
     def private_key_pem(self) -> pulumi.Output[str]:
+        """
+        The certificate's private key, in PEM format, if the
+        certificate was generated from scratch and not with
+        `certificate_request_pem`.  If
+        `certificate_request_pem` was used, this will be blank.
+        """
         return pulumi.get(self, "private_key_pem")
 
     @property
     @pulumi.getter(name="recursiveNameservers")
     def recursive_nameservers(self) -> pulumi.Output[Optional[Sequence[str]]]:
+        """
+        The recursive nameservers that will be
+        used to check for propagation of DNS challenge records. Defaults to your
+        system-configured DNS resolvers.
+        """
         return pulumi.get(self, "recursive_nameservers")
 
     @property
     @pulumi.getter(name="revokeCertificateOnDestroy")
     def revoke_certificate_on_destroy(self) -> pulumi.Output[Optional[bool]]:
+        """
+        Enables revocation of a certificate upon destroy,
+        which includes when a resource is re-created. Default is `true`.
+        """
         return pulumi.get(self, "revoke_certificate_on_destroy")
 
     @property
     @pulumi.getter(name="subjectAlternativeNames")
     def subject_alternative_names(self) -> pulumi.Output[Optional[Sequence[str]]]:
+        """
+        The certificate's subject alternative names,
+        domains that this certificate will also be recognized for. Only valid when not
+        specifying a CSR. Forces a new resource when changed.
+        """
         return pulumi.get(self, "subject_alternative_names")
 
     @property
     @pulumi.getter(name="tlsChallenge")
     def tls_challenge(self) -> pulumi.Output[Optional['outputs.CertificateTlsChallenge']]:
+        """
+        Defines a TLS challenge to use in fulfilling the
+        request.
+
+        > Only one of `http_challenge`, `http_webroot_challenge`, and
+        `http_memcached_challenge` can be defined at once. See the section on Using
+        HTTP and TLS challenges for more details on
+        using these and `tls_challenge`.
+        """
         return pulumi.get(self, "tls_challenge")
 

--- a/sdk/python/pulumiverse_acme/outputs.py
+++ b/sdk/python/pulumiverse_acme/outputs.py
@@ -60,6 +60,22 @@ class CertificateHttpChallenge(dict):
     def __init__(__self__, *,
                  port: Optional[int] = None,
                  proxy_header: Optional[str] = None):
+        """
+        :param int port: The port that the challenge server listens on. Default: `80`.
+        :param str proxy_header: The proxy header to match against. Default:
+               `Host`.
+               
+               The `proxy_header` option behaves differently depending on its definition:
+               
+               * When set to `Host`, standard host header validation is used.
+               * When set to `Forwarded`, the server looks in the `Forwarded` header for a
+               section matching `host=DOMAIN` where `DOMAIN` is the domain currently being
+               resolved by the challenge. See [RFC 7239](https://tools.ietf.org/html/rfc7239)
+               for more details.
+               * When set to an arbitrary header (example: `X-Forwarded-Host`), that header is
+               checked for the host entry in the same way the host header would normally be
+               checked.
+        """
         if port is not None:
             pulumi.set(__self__, "port", port)
         if proxy_header is not None:
@@ -68,11 +84,29 @@ class CertificateHttpChallenge(dict):
     @property
     @pulumi.getter
     def port(self) -> Optional[int]:
+        """
+        The port that the challenge server listens on. Default: `80`.
+        """
         return pulumi.get(self, "port")
 
     @property
     @pulumi.getter(name="proxyHeader")
     def proxy_header(self) -> Optional[str]:
+        """
+        The proxy header to match against. Default:
+        `Host`.
+
+        The `proxy_header` option behaves differently depending on its definition:
+
+        * When set to `Host`, standard host header validation is used.
+        * When set to `Forwarded`, the server looks in the `Forwarded` header for a
+        section matching `host=DOMAIN` where `DOMAIN` is the domain currently being
+        resolved by the challenge. See [RFC 7239](https://tools.ietf.org/html/rfc7239)
+        for more details.
+        * When set to an arbitrary header (example: `X-Forwarded-Host`), that header is
+        checked for the host entry in the same way the host header would normally be
+        checked.
+        """
         return pulumi.get(self, "proxy_header")
 
 
@@ -80,11 +114,17 @@ class CertificateHttpChallenge(dict):
 class CertificateHttpMemcachedChallenge(dict):
     def __init__(__self__, *,
                  hosts: Sequence[str]):
+        """
+        :param Sequence[str] hosts: The hosts to publish the record to.
+        """
         pulumi.set(__self__, "hosts", hosts)
 
     @property
     @pulumi.getter
     def hosts(self) -> Sequence[str]:
+        """
+        The hosts to publish the record to.
+        """
         return pulumi.get(self, "hosts")
 
 
@@ -92,11 +132,17 @@ class CertificateHttpMemcachedChallenge(dict):
 class CertificateHttpWebrootChallenge(dict):
     def __init__(__self__, *,
                  directory: str):
+        """
+        :param str directory: The directory to publish the record to.
+        """
         pulumi.set(__self__, "directory", directory)
 
     @property
     @pulumi.getter
     def directory(self) -> str:
+        """
+        The directory to publish the record to.
+        """
         return pulumi.get(self, "directory")
 
 
@@ -104,12 +150,18 @@ class CertificateHttpWebrootChallenge(dict):
 class CertificateTlsChallenge(dict):
     def __init__(__self__, *,
                  port: Optional[int] = None):
+        """
+        :param int port: The port that the challenge server listens on. Default: `443`.
+        """
         if port is not None:
             pulumi.set(__self__, "port", port)
 
     @property
     @pulumi.getter
     def port(self) -> Optional[int]:
+        """
+        The port that the challenge server listens on. Default: `443`.
+        """
         return pulumi.get(self, "port")
 
 


### PR DESCRIPTION
Fixes: #3 

* Regenerated the SDKs so they include the converted TF resource & datasource documentation in the generated files
* Added the `docs` folder which is required for publishing in the Pulumi Registry