### PR TITLE
Spawn the process for the dnsplugin

### DIFF
--- a/provider/cmd/pulumi-resource-acme/main.go
+++ b/provider/cmd/pulumi-resource-acme/main.go
@@ -18,16 +18,22 @@ package main
 
 import (
 	_ "embed"
+	"os"
 
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 	acme "github.com/pulumiverse/pulumi-acme/provider"
 	"github.com/pulumiverse/pulumi-acme/provider/pkg/version"
+	"github.com/vancluever/terraform-provider-acme/v2/acme/dnsplugin"
 )
 
 //go:embed schema-embed.json
 var pulumiSchema []byte
 
 func main() {
-	// Modify the path to point to the new provider
-	tfbridge.Main("acme", version.Version, acme.Provider(), pulumiSchema)
+	if len(os.Args) == 2 && os.Args[1] == dnsplugin.PluginArg {
+		// Start the plugin here
+		dnsplugin.Serve()
+	} else {
+		tfbridge.Main("acme", version.Version, acme.Provider(), pulumiSchema)
+	}
 }


### PR DESCRIPTION
Duplicate the code from the Terraform provider to launch the provider as a DNS challenche plugin provider:

https://github.com/vancluever/terraform-provider-acme/blob/6160ecc34318af7f133c35b0802d565f5bda4b03/main.go#L12-L15

I tested this succesfully using a local build with DNSimple as my DNS provider, against the LetsEncrypt staging environment:

```
Updating (dev)

View in Browser (Ctrl+O): https://app.pulumi.com/ringods/ipxe-bootstrap-infra/dev/updates/5

     Type                       Name                      Status            Info
     pulumi:pulumi:Stack        ipxe-bootstrap-infra-dev                    6 warnings; 25 messages
 +   └─ acme:index:Certificate  certificate               created (15s)     


Diagnostics:
  pulumi:pulumi:Stack (ipxe-bootstrap-infra-dev):
    warning: using pulumi-resource-acme from $PATH at /Users/ringods/Projects/pulumiverse/pulumi-acme/bin/pulumi-resource-acme
    warning: using pulumi-resource-acme from $PATH at /Users/ringods/Projects/pulumiverse/pulumi-acme/bin/pulumi-resource-acme
    warning: using pulumi-resource-acme from $PATH at /Users/ringods/Projects/pulumiverse/pulumi-acme/bin/pulumi-resource-acme
    warning: resource plugin acme is expected to have version >=0.0.1, but has 0.0.1-alpha.1695224255+44465925.dirty; the wrong version may be on your path, or this may be a bug in the plugin
    warning: using pulumi-resource-acme from $PATH at /Users/ringods/Projects/pulumiverse/pulumi-acme/bin/pulumi-resource-acme
    warning: resource plugin acme is expected to have version >=0.0.1, but has 0.0.1-alpha.1695224255+44465925.dirty; the wrong version may be on your path, or this may be a bug in the plugin

    2023/09/25 08:37:30 [INFO] acme: Trying to resolve account by key
    2023-09-25T08:37:30.570+0200 [INFO]  plugin: configuring client automatic mTLS
    2023-09-25T08:37:30.584+0200 [DEBUG] plugin: starting plugin: path=/Users/ringods/Projects/pulumiverse/pulumi-acme/bin/pulumi-resource-acme args=["/Users/ringods/Projects/pulumiverse/pulumi-acme/bin/pulumi-resource-acme", "-dnsplugin"]
    2023-09-25T08:37:30.588+0200 [DEBUG] plugin: plugin started: path=/Users/ringods/Projects/pulumiverse/pulumi-acme/bin/pulumi-resource-acme pid=42635
    2023-09-25T08:37:30.588+0200 [DEBUG] plugin: waiting for RPC address: plugin=/Users/ringods/Projects/pulumiverse/pulumi-acme/bin/pulumi-resource-acme
    2023-09-25T08:37:30.632+0200 [INFO]  plugin.pulumi-resource-acme: configuring server automatic mTLS: timestamp="2023-09-25T08:37:30.632+0200"
    2023-09-25T08:37:30.644+0200 [DEBUG] plugin.pulumi-resource-acme: plugin address: address=/var/folders/mp/9wctftz9039d4jdch0y48r780000gn/T/plugin3256270209 network=unix timestamp="2023-09-25T08:37:30.644+0200"
    2023-09-25T08:37:30.644+0200 [DEBUG] plugin: using plugin: version=1
    2023-09-25T08:37:30.652+0200 [TRACE] plugin.stdio: waiting for stdio data
    2023/09/25 08:37:30 [INFO] [<domain-redacted>] acme: Obtaining bundled SAN certificate
    2023/09/25 08:37:31 [INFO] [<domain-redacted>] AuthURL: https://acme-staging-v02.api.letsencrypt.org/acme/authz-v3/8489010134
    2023/09/25 08:37:31 [INFO] [<domain-redacted>] acme: Could not find solver for: tls-alpn-01
    2023/09/25 08:37:31 [INFO] [<domain-redacted>] acme: Could not find solver for: http-01
    2023/09/25 08:37:31 [INFO] [<domain-redacted>] acme: use dns-01 solver
    2023/09/25 08:37:31 [INFO] [<domain-redacted>] acme: Preparing to solve DNS-01
    2023/09/25 08:37:35 [INFO] [<domain-redacted>] acme: Trying to solve DNS-01
    2023/09/25 08:37:35 [INFO] [<domain-redacted>] acme: Checking DNS record propagation using [8.8.8.8:53]
    2023/09/25 08:37:37 [INFO] Wait for propagation [timeout: 1m0s, interval: 2s]
    2023/09/25 08:37:41 [INFO] [<domain-redacted>] The server validated our request
    2023/09/25 08:37:41 [INFO] [<domain-redacted>] acme: Cleaning DNS-01 challenge
    2023/09/25 08:37:42 [INFO] [<domain-redacted>] acme: Validations succeeded; requesting certificates
    2023/09/25 08:37:42 [INFO] Wait for certificate [timeout: 30s, interval: 500ms]
    2023/09/25 08:37:44 [INFO] [<domain-redacted>] Server responded with a certificate.
    2023-09-25T08:37:44.104+0200 [DEBUG] plugin.stdio: received EOF, stopping recv loop: err="rpc error: code = Unavailable desc = error reading from server: EOF"
    2023-09-25T08:37:44.107+0200 [INFO]  plugin: plugin process exited: plugin=/Users/ringods/Projects/pulumiverse/pulumi-acme/bin/pulumi-resource-acme id=42635

Resources:
    + 1 created
    3 unchanged

Duration: 20s
```