### PR TITLE
Upgrade terraform-provider-acme to v2.18.0

### DIFF
--- a/provider/cmd/pulumi-resource-acme/schema.json
+++ b/provider/cmd/pulumi-resource-acme/schema.json
@@ -188,6 +188,10 @@
                     "description": "The private key of the account that is\nrequesting the certificate. Forces a new resource when changed.\n",
                     "secret": true
                 },
+                "certTimeout": {
+                    "type": "integer",
+                    "description": "Controls the timeout in seconds for certificate requests\nthat are made after challenges are complete. Defaults to 30 seconds.\n\n\u003e As mentioned, `cert_timeout` does nothing until all challenges are complete.\nIf you are looking to control timeouts related to a particular challenge (such\nas a DNS challenge), see that challenge provider's specific options.\n"
+                },
                 "certificateDomain": {
                     "type": "string",
                     "description": "The common name of the certificate.\n"
@@ -318,6 +322,10 @@
                     "secret": true,
                     "willReplaceOnChanges": true
                 },
+                "certTimeout": {
+                    "type": "integer",
+                    "description": "Controls the timeout in seconds for certificate requests\nthat are made after challenges are complete. Defaults to 30 seconds.\n\n\u003e As mentioned, `cert_timeout` does nothing until all challenges are complete.\nIf you are looking to control timeouts related to a particular challenge (such\nas a DNS challenge), see that challenge provider's specific options.\n"
+                },
                 "certificateP12Password": {
                     "type": "string",
                     "description": "Password to be used when generating\nthe PFX file stored in `certificate_p12`. Defaults to an\nempty string.\n",
@@ -418,6 +426,10 @@
                         "description": "The private key of the account that is\nrequesting the certificate. Forces a new resource when changed.\n",
                         "secret": true,
                         "willReplaceOnChanges": true
+                    },
+                    "certTimeout": {
+                        "type": "integer",
+                        "description": "Controls the timeout in seconds for certificate requests\nthat are made after challenges are complete. Defaults to 30 seconds.\n\n\u003e As mentioned, `cert_timeout` does nothing until all challenges are complete.\nIf you are looking to control timeouts related to a particular challenge (such\nas a DNS challenge), see that challenge provider's specific options.\n"
                     },
                     "certificateDomain": {
                         "type": "string",

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -8,7 +8,7 @@ replace github.com/hashicorp/terraform-plugin-sdk/v2 => github.com/pulumi/terraf
 
 require (
 	github.com/pulumi/pulumi-terraform-bridge/v3 v3.83.0
-	github.com/vancluever/terraform-provider-acme/v2 v2.17.1
+	github.com/vancluever/terraform-provider-acme/v2 v2.18.0
 )
 
 require (
@@ -113,7 +113,7 @@ require (
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/gedex/inflector v0.0.0-20170307190818-16278e9db813 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect
-	github.com/go-acme/lego/v4 v4.14.0 // indirect
+	github.com/go-acme/lego/v4 v4.14.2 // indirect
 	github.com/go-errors/errors v1.0.1 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.5.0 // indirect
@@ -216,6 +216,7 @@ require (
 	github.com/namedotcom/go v0.0.0-20180403034216-08470befbe04 // indirect
 	github.com/natefinch/atomic v1.0.1 // indirect
 	github.com/nrdcg/auroradns v1.1.0 // indirect
+	github.com/nrdcg/bunny-go v0.0.0-20230728143221-c9dda82568d9 // indirect
 	github.com/nrdcg/desec v0.7.0 // indirect
 	github.com/nrdcg/dnspod-go v0.4.0 // indirect
 	github.com/nrdcg/freemyip v0.2.0 // indirect
@@ -228,7 +229,7 @@ require (
 	github.com/opentracing/basictracer-go v1.1.0 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/oracle/oci-go-sdk v24.3.0+incompatible // indirect
-	github.com/ovh/go-ovh v1.4.1 // indirect
+	github.com/ovh/go-ovh v1.4.2 // indirect
 	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
 	github.com/pgavlin/fx v0.1.6 // indirect
 	github.com/pgavlin/goldmark v1.1.33-0.20200616210433-b5eb04559386 // indirect
@@ -265,7 +266,6 @@ require (
 	github.com/segmentio/encoding v0.3.5 // indirect
 	github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect
-	github.com/simplesurance/bunny-go v0.0.0-20221115111006-e11d9dc91f04 // indirect
 	github.com/sirupsen/logrus v1.9.0 // indirect
 	github.com/skeema/knownhosts v1.2.2 // indirect
 	github.com/smartystreets/go-aws-auth v0.0.0-20180515143844-0c1422d1fdb9 // indirect

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -1888,8 +1888,8 @@ github.com/gliderlabs/ssh v0.2.2/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aev
 github.com/gliderlabs/ssh v0.3.5/go.mod h1:8XB4KraRrX39qHhT6yxPsHedjA08I/uBVwj4xC+/+z4=
 github.com/gliderlabs/ssh v0.3.7 h1:iV3Bqi942d9huXnzEF2Mt+CY9gLu8DNM4Obd+8bODRE=
 github.com/gliderlabs/ssh v0.3.7/go.mod h1:zpHEXBstFnQYtGnB8k8kQLol82umzn/2/snG7alWVD8=
-github.com/go-acme/lego/v4 v4.14.0 h1:/skZoRHgVh0d2RK7l1g3Ch8HqeqP9LB8ZEjLdGEpcDE=
-github.com/go-acme/lego/v4 v4.14.0/go.mod h1:zjmvNCDLGz7GrC1OqdVpVmZFKSRabEDtWbdzmcpBsGo=
+github.com/go-acme/lego/v4 v4.14.2 h1:/D/jqRgLi8Cbk33sLGtu2pX2jEg3bGJWHyV8kFuUHGM=
+github.com/go-acme/lego/v4 v4.14.2/go.mod h1:kBXxbeTg0x9AgaOYjPSwIeJy3Y33zTz+tMD16O4MO6c=
 github.com/go-asn1-ber/asn1-ber v1.3.1/go.mod h1:hEBeB/ic+5LoWskz+yKT7vGhhPYkProFKoKdwZRWMe0=
 github.com/go-chi/chi/v5 v5.0.0/go.mod h1:BBug9lr0cqtdAhsu6R4AAdvufI0/XBzAQSsUqJpoZOs=
 github.com/go-cmd/cmd v1.0.5/go.mod h1:y8q8qlK5wQibcw63djSl/ntiHUHXHGdCkPk0j4QeW4s=
@@ -2809,6 +2809,8 @@ github.com/nightlyone/lockfile v1.0.0 h1:RHep2cFKK4PonZJDdEl4GmkabuhbsRMgk/k3uAm
 github.com/nightlyone/lockfile v1.0.0/go.mod h1:rywoIealpdNse2r832aiD9jRk8ErCatROs6LzC841CI=
 github.com/nrdcg/auroradns v1.1.0 h1:KekGh8kmf2MNwqZVVYo/fw/ZONt8QMEmbMFOeljteWo=
 github.com/nrdcg/auroradns v1.1.0/go.mod h1:O7tViUZbAcnykVnrGkXzIJTHoQCHcgalgAe6X1mzHfk=
+github.com/nrdcg/bunny-go v0.0.0-20230728143221-c9dda82568d9 h1:qpB3wZR4+MPK92cTC9zZPnndkJgDgPvQqPUAgVc1NXU=
+github.com/nrdcg/bunny-go v0.0.0-20230728143221-c9dda82568d9/go.mod h1:HUoHXDrFvidN1NK9Wb/mZKNOfDNutKkzF2Pg71M9hHA=
 github.com/nrdcg/desec v0.7.0 h1:iuGhi4pstF3+vJWwt292Oqe2+AsSPKDynQna/eu1fDs=
 github.com/nrdcg/desec v0.7.0/go.mod h1:e1uRqqKv1mJdd5+SQROAhmy75lKMphLzWIuASLkpeFY=
 github.com/nrdcg/dnspod-go v0.4.0 h1:c/jn1mLZNKF3/osJ6mz3QPxTudvPArXTjpkmYj0uK6U=
@@ -2934,8 +2936,8 @@ github.com/openzipkin/zipkin-go v0.2.1/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnh
 github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/oracle/oci-go-sdk v24.3.0+incompatible h1:x4mcfb4agelf1O4/1/auGlZ1lr97jXRSSN5MxTgG/zU=
 github.com/oracle/oci-go-sdk v24.3.0+incompatible/go.mod h1:VQb79nF8Z2cwLkLS35ukwStZIg5F66tcBccjip/j888=
-github.com/ovh/go-ovh v1.4.1 h1:VBGa5wMyQtTP7Zb+w97zRCh9sLtM/2YKRyy+MEJmWaM=
-github.com/ovh/go-ovh v1.4.1/go.mod h1:6bL6pPyUT7tBfI0pqOegJgRjgjuO+mOo+MyXd1EEC0M=
+github.com/ovh/go-ovh v1.4.2 h1:ub4jVK6ERbiBTo4y5wbLCjeKCjGY+K36e7BviW+MaAU=
+github.com/ovh/go-ovh v1.4.2/go.mod h1:AkPXVtgwB6xlKblMjRKJJmjRp+ogrE7fz2lVgcQY8SY=
 github.com/pact-foundation/pact-go v1.0.4/go.mod h1:uExwJY4kCzNPcHRj+hCR/HBbOOIwwtUjcrb0b5/5kLM=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0 h1:cBOtyMzM9HTpWjXfbbunk26uA6nG3a8n06Wieeh0MwY=
@@ -3149,8 +3151,6 @@ github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFR
 github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749/go.mod h1:ZY1cvUeJuFPAdZ/B6v7RHavJWZn2YPVFQ1OSXhCGOkg=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/shurcooL/vfsgen v0.0.0-20200824052919-0d455de96546/go.mod h1:TrYk7fJVaAttu97ZZKrO9UbRa8izdowaMIZcxYMbVaw=
-github.com/simplesurance/bunny-go v0.0.0-20221115111006-e11d9dc91f04 h1:ZTzdx88+AcnjqUfJwnz89UBrMSBQ1NEysg9u5d+dU9c=
-github.com/simplesurance/bunny-go v0.0.0-20221115111006-e11d9dc91f04/go.mod h1:5KS21fpch8TIMyAUv/qQqTa3GZfBDYgjaZbd2KXKYfg=
 github.com/sirupsen/logrus v1.0.4-0.20170822132746-89742aefa4b2/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
 github.com/sirupsen/logrus v1.0.6/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
@@ -3287,8 +3287,8 @@ github.com/urfave/cli v1.22.2/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtX
 github.com/urfave/cli/v2 v2.25.7/go.mod h1:8qnjx1vcq5s2/wpsqoZFndg2CE5tNFyrTvS6SinrnYQ=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasttemplate v1.2.1/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
-github.com/vancluever/terraform-provider-acme/v2 v2.17.1 h1:ctNUFzHOqNp/awD4+Rt2Hk4nc4tzcz3sBXyqawjbyoA=
-github.com/vancluever/terraform-provider-acme/v2 v2.17.1/go.mod h1:E/QZ6TUJYFUWAoh7T3RiL3b9ZyiSZF/lf2ZPHR+G5vg=
+github.com/vancluever/terraform-provider-acme/v2 v2.18.0 h1:JqUHkPT5SwdnZq62N1/vgegXH5ED5ozmLSrGjvnLf6A=
+github.com/vancluever/terraform-provider-acme/v2 v2.18.0/go.mod h1:I4B81Pxlj9+djsNFK4C7EbNuluYDakacktZFG7l7u1A=
 github.com/vinyldns/go-vinyldns v0.9.16 h1:GZJStDkcCk1F1AcRc64LuuMh+ENL8pHA0CVd4ulRMcQ=
 github.com/vinyldns/go-vinyldns v0.9.16/go.mod h1:5qIJOdmzAnatKjurI+Tl4uTus7GJKJxb+zitufjHs3Q=
 github.com/vishvananda/netlink v0.0.0-20181108222139-023a6dafdcdf/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=
@@ -4506,7 +4506,7 @@ google.golang.org/grpc v1.55.0/go.mod h1:iYEXKGkEBhg1PjZQvoYEVPTDkHo1/bjTnfwTeGO
 google.golang.org/grpc v1.56.1/go.mod h1:I9bI3vqKfayGqPUAwGdOSu7kt6oIJLixfffKrpXqQ9s=
 google.golang.org/grpc v1.56.2/go.mod h1:I9bI3vqKfayGqPUAwGdOSu7kt6oIJLixfffKrpXqQ9s=
 google.golang.org/grpc v1.57.0/go.mod h1:Sd+9RMTACXwmub0zcNY2c4arhtrbBYD1AUHI/dt16Mo=
-google.golang.org/grpc v1.58.0/go.mod h1:tgX3ZQDlNJGU96V6yHh1T/JeoBQ2TXdr43YbYSsCJk0=
+google.golang.org/grpc v1.58.1/go.mod h1:tgX3ZQDlNJGU96V6yHh1T/JeoBQ2TXdr43YbYSsCJk0=
 google.golang.org/grpc v1.58.2/go.mod h1:tgX3ZQDlNJGU96V6yHh1T/JeoBQ2TXdr43YbYSsCJk0=
 google.golang.org/grpc v1.58.3/go.mod h1:tgX3ZQDlNJGU96V6yHh1T/JeoBQ2TXdr43YbYSsCJk0=
 google.golang.org/grpc v1.59.0/go.mod h1:aUPDwccQo6OTjy7Hct4AfBPD1GptF4fyUjIkQ9YtF98=

--- a/sdk/dotnet/Certificate.cs
+++ b/sdk/dotnet/Certificate.cs
@@ -21,6 +21,17 @@ namespace Pulumiverse.Acme
         public Output<string> AccountKeyPem { get; private set; } = null!;
 
         /// <summary>
+        /// Controls the timeout in seconds for certificate requests
+        /// that are made after challenges are complete. Defaults to 30 seconds.
+        /// 
+        /// &gt; As mentioned, `cert_timeout` does nothing until all challenges are complete.
+        /// If you are looking to control timeouts related to a particular challenge (such
+        /// as a DNS challenge), see that challenge provider's specific options.
+        /// </summary>
+        [Output("certTimeout")]
+        public Output<int?> CertTimeout { get; private set; } = null!;
+
+        /// <summary>
         /// The common name of the certificate.
         /// </summary>
         [Output("certificateDomain")]
@@ -327,6 +338,17 @@ namespace Pulumiverse.Acme
             }
         }
 
+        /// <summary>
+        /// Controls the timeout in seconds for certificate requests
+        /// that are made after challenges are complete. Defaults to 30 seconds.
+        /// 
+        /// &gt; As mentioned, `cert_timeout` does nothing until all challenges are complete.
+        /// If you are looking to control timeouts related to a particular challenge (such
+        /// as a DNS challenge), see that challenge provider's specific options.
+        /// </summary>
+        [Input("certTimeout")]
+        public Input<int>? CertTimeout { get; set; }
+
         [Input("certificateP12Password")]
         private Input<string>? _certificateP12Password;
 
@@ -561,6 +583,17 @@ namespace Pulumiverse.Acme
                 _accountKeyPem = Output.Tuple<Input<string>?, int>(value, emptySecret).Apply(t => t.Item1);
             }
         }
+
+        /// <summary>
+        /// Controls the timeout in seconds for certificate requests
+        /// that are made after challenges are complete. Defaults to 30 seconds.
+        /// 
+        /// &gt; As mentioned, `cert_timeout` does nothing until all challenges are complete.
+        /// If you are looking to control timeouts related to a particular challenge (such
+        /// as a DNS challenge), see that challenge provider's specific options.
+        /// </summary>
+        [Input("certTimeout")]
+        public Input<int>? CertTimeout { get; set; }
 
         /// <summary>
         /// The common name of the certificate.

--- a/sdk/go/acme/certificate.go
+++ b/sdk/go/acme/certificate.go
@@ -18,6 +18,13 @@ type Certificate struct {
 	// The private key of the account that is
 	// requesting the certificate. Forces a new resource when changed.
 	AccountKeyPem pulumi.StringOutput `pulumi:"accountKeyPem"`
+	// Controls the timeout in seconds for certificate requests
+	// that are made after challenges are complete. Defaults to 30 seconds.
+	//
+	// > As mentioned, `certTimeout` does nothing until all challenges are complete.
+	// If you are looking to control timeouts related to a particular challenge (such
+	// as a DNS challenge), see that challenge provider's specific options.
+	CertTimeout pulumi.IntPtrOutput `pulumi:"certTimeout"`
 	// The common name of the certificate.
 	CertificateDomain pulumi.StringOutput `pulumi:"certificateDomain"`
 	// The expiry date of the certificate, laid out in
@@ -205,6 +212,13 @@ type certificateState struct {
 	// The private key of the account that is
 	// requesting the certificate. Forces a new resource when changed.
 	AccountKeyPem *string `pulumi:"accountKeyPem"`
+	// Controls the timeout in seconds for certificate requests
+	// that are made after challenges are complete. Defaults to 30 seconds.
+	//
+	// > As mentioned, `certTimeout` does nothing until all challenges are complete.
+	// If you are looking to control timeouts related to a particular challenge (such
+	// as a DNS challenge), see that challenge provider's specific options.
+	CertTimeout *int `pulumi:"certTimeout"`
 	// The common name of the certificate.
 	CertificateDomain *string `pulumi:"certificateDomain"`
 	// The expiry date of the certificate, laid out in
@@ -347,6 +361,13 @@ type CertificateState struct {
 	// The private key of the account that is
 	// requesting the certificate. Forces a new resource when changed.
 	AccountKeyPem pulumi.StringPtrInput
+	// Controls the timeout in seconds for certificate requests
+	// that are made after challenges are complete. Defaults to 30 seconds.
+	//
+	// > As mentioned, `certTimeout` does nothing until all challenges are complete.
+	// If you are looking to control timeouts related to a particular challenge (such
+	// as a DNS challenge), see that challenge provider's specific options.
+	CertTimeout pulumi.IntPtrInput
 	// The common name of the certificate.
 	CertificateDomain pulumi.StringPtrInput
 	// The expiry date of the certificate, laid out in
@@ -493,6 +514,13 @@ type certificateArgs struct {
 	// The private key of the account that is
 	// requesting the certificate. Forces a new resource when changed.
 	AccountKeyPem string `pulumi:"accountKeyPem"`
+	// Controls the timeout in seconds for certificate requests
+	// that are made after challenges are complete. Defaults to 30 seconds.
+	//
+	// > As mentioned, `certTimeout` does nothing until all challenges are complete.
+	// If you are looking to control timeouts related to a particular challenge (such
+	// as a DNS challenge), see that challenge provider's specific options.
+	CertTimeout *int `pulumi:"certTimeout"`
 	// Password to be used when generating
 	// the PFX file stored in `certificateP12`. Defaults to an
 	// empty string.
@@ -610,6 +638,13 @@ type CertificateArgs struct {
 	// The private key of the account that is
 	// requesting the certificate. Forces a new resource when changed.
 	AccountKeyPem pulumi.StringInput
+	// Controls the timeout in seconds for certificate requests
+	// that are made after challenges are complete. Defaults to 30 seconds.
+	//
+	// > As mentioned, `certTimeout` does nothing until all challenges are complete.
+	// If you are looking to control timeouts related to a particular challenge (such
+	// as a DNS challenge), see that challenge provider's specific options.
+	CertTimeout pulumi.IntPtrInput
 	// Password to be used when generating
 	// the PFX file stored in `certificateP12`. Defaults to an
 	// empty string.
@@ -813,6 +848,16 @@ func (o CertificateOutput) ToCertificateOutputWithContext(ctx context.Context) C
 // requesting the certificate. Forces a new resource when changed.
 func (o CertificateOutput) AccountKeyPem() pulumi.StringOutput {
 	return o.ApplyT(func(v *Certificate) pulumi.StringOutput { return v.AccountKeyPem }).(pulumi.StringOutput)
+}
+
+// Controls the timeout in seconds for certificate requests
+// that are made after challenges are complete. Defaults to 30 seconds.
+//
+// > As mentioned, `certTimeout` does nothing until all challenges are complete.
+// If you are looking to control timeouts related to a particular challenge (such
+// as a DNS challenge), see that challenge provider's specific options.
+func (o CertificateOutput) CertTimeout() pulumi.IntPtrOutput {
+	return o.ApplyT(func(v *Certificate) pulumi.IntPtrOutput { return v.CertTimeout }).(pulumi.IntPtrOutput)
 }
 
 // The common name of the certificate.

--- a/sdk/nodejs/certificate.ts
+++ b/sdk/nodejs/certificate.ts
@@ -40,6 +40,15 @@ export class Certificate extends pulumi.CustomResource {
      */
     public readonly accountKeyPem!: pulumi.Output<string>;
     /**
+     * Controls the timeout in seconds for certificate requests
+     * that are made after challenges are complete. Defaults to 30 seconds.
+     *
+     * > As mentioned, `certTimeout` does nothing until all challenges are complete.
+     * If you are looking to control timeouts related to a particular challenge (such
+     * as a DNS challenge), see that challenge provider's specific options.
+     */
+    public readonly certTimeout!: pulumi.Output<number | undefined>;
+    /**
      * The common name of the certificate.
      */
     public /*out*/ readonly certificateDomain!: pulumi.Output<string>;
@@ -240,6 +249,7 @@ export class Certificate extends pulumi.CustomResource {
         if (opts.id) {
             const state = argsOrState as CertificateState | undefined;
             resourceInputs["accountKeyPem"] = state ? state.accountKeyPem : undefined;
+            resourceInputs["certTimeout"] = state ? state.certTimeout : undefined;
             resourceInputs["certificateDomain"] = state ? state.certificateDomain : undefined;
             resourceInputs["certificateNotAfter"] = state ? state.certificateNotAfter : undefined;
             resourceInputs["certificateP12"] = state ? state.certificateP12 : undefined;
@@ -271,6 +281,7 @@ export class Certificate extends pulumi.CustomResource {
                 throw new Error("Missing required property 'accountKeyPem'");
             }
             resourceInputs["accountKeyPem"] = args?.accountKeyPem ? pulumi.secret(args.accountKeyPem) : undefined;
+            resourceInputs["certTimeout"] = args ? args.certTimeout : undefined;
             resourceInputs["certificateP12Password"] = args?.certificateP12Password ? pulumi.secret(args.certificateP12Password) : undefined;
             resourceInputs["certificateRequestPem"] = args ? args.certificateRequestPem : undefined;
             resourceInputs["commonName"] = args ? args.commonName : undefined;
@@ -313,6 +324,15 @@ export interface CertificateState {
      * requesting the certificate. Forces a new resource when changed.
      */
     accountKeyPem?: pulumi.Input<string>;
+    /**
+     * Controls the timeout in seconds for certificate requests
+     * that are made after challenges are complete. Defaults to 30 seconds.
+     *
+     * > As mentioned, `certTimeout` does nothing until all challenges are complete.
+     * If you are looking to control timeouts related to a particular challenge (such
+     * as a DNS challenge), see that challenge provider's specific options.
+     */
+    certTimeout?: pulumi.Input<number>;
     /**
      * The common name of the certificate.
      */
@@ -510,6 +530,15 @@ export interface CertificateArgs {
      * requesting the certificate. Forces a new resource when changed.
      */
     accountKeyPem: pulumi.Input<string>;
+    /**
+     * Controls the timeout in seconds for certificate requests
+     * that are made after challenges are complete. Defaults to 30 seconds.
+     *
+     * > As mentioned, `certTimeout` does nothing until all challenges are complete.
+     * If you are looking to control timeouts related to a particular challenge (such
+     * as a DNS challenge), see that challenge provider's specific options.
+     */
+    certTimeout?: pulumi.Input<number>;
     /**
      * Password to be used when generating
      * the PFX file stored in `certificateP12`. Defaults to an

--- a/sdk/python/pulumiverse_acme/certificate.py
+++ b/sdk/python/pulumiverse_acme/certificate.py
@@ -17,6 +17,7 @@ __all__ = ['CertificateArgs', 'Certificate']
 class CertificateArgs:
     def __init__(__self__, *,
                  account_key_pem: pulumi.Input[str],
+                 cert_timeout: Optional[pulumi.Input[int]] = None,
                  certificate_p12_password: Optional[pulumi.Input[str]] = None,
                  certificate_request_pem: Optional[pulumi.Input[str]] = None,
                  common_name: Optional[pulumi.Input[str]] = None,
@@ -39,6 +40,12 @@ class CertificateArgs:
         The set of arguments for constructing a Certificate resource.
         :param pulumi.Input[str] account_key_pem: The private key of the account that is
                requesting the certificate. Forces a new resource when changed.
+        :param pulumi.Input[int] cert_timeout: Controls the timeout in seconds for certificate requests
+               that are made after challenges are complete. Defaults to 30 seconds.
+               
+               > As mentioned, `cert_timeout` does nothing until all challenges are complete.
+               If you are looking to control timeouts related to a particular challenge (such
+               as a DNS challenge), see that challenge provider's specific options.
         :param pulumi.Input[str] certificate_p12_password: Password to be used when generating
                the PFX file stored in `certificate_p12`. Defaults to an
                empty string.
@@ -133,6 +140,8 @@ class CertificateArgs:
                details on using these and `tls_challenge`.
         """
         pulumi.set(__self__, "account_key_pem", account_key_pem)
+        if cert_timeout is not None:
+            pulumi.set(__self__, "cert_timeout", cert_timeout)
         if certificate_p12_password is not None:
             pulumi.set(__self__, "certificate_p12_password", certificate_p12_password)
         if certificate_request_pem is not None:
@@ -182,6 +191,23 @@ class CertificateArgs:
     @account_key_pem.setter
     def account_key_pem(self, value: pulumi.Input[str]):
         pulumi.set(self, "account_key_pem", value)
+
+    @property
+    @pulumi.getter(name="certTimeout")
+    def cert_timeout(self) -> Optional[pulumi.Input[int]]:
+        """
+        Controls the timeout in seconds for certificate requests
+        that are made after challenges are complete. Defaults to 30 seconds.
+
+        > As mentioned, `cert_timeout` does nothing until all challenges are complete.
+        If you are looking to control timeouts related to a particular challenge (such
+        as a DNS challenge), see that challenge provider's specific options.
+        """
+        return pulumi.get(self, "cert_timeout")
+
+    @cert_timeout.setter
+    def cert_timeout(self, value: Optional[pulumi.Input[int]]):
+        pulumi.set(self, "cert_timeout", value)
 
     @property
     @pulumi.getter(name="certificateP12Password")
@@ -478,6 +504,7 @@ class CertificateArgs:
 class _CertificateState:
     def __init__(__self__, *,
                  account_key_pem: Optional[pulumi.Input[str]] = None,
+                 cert_timeout: Optional[pulumi.Input[int]] = None,
                  certificate_domain: Optional[pulumi.Input[str]] = None,
                  certificate_not_after: Optional[pulumi.Input[str]] = None,
                  certificate_p12: Optional[pulumi.Input[str]] = None,
@@ -507,6 +534,12 @@ class _CertificateState:
         Input properties used for looking up and filtering Certificate resources.
         :param pulumi.Input[str] account_key_pem: The private key of the account that is
                requesting the certificate. Forces a new resource when changed.
+        :param pulumi.Input[int] cert_timeout: Controls the timeout in seconds for certificate requests
+               that are made after challenges are complete. Defaults to 30 seconds.
+               
+               > As mentioned, `cert_timeout` does nothing until all challenges are complete.
+               If you are looking to control timeouts related to a particular challenge (such
+               as a DNS challenge), see that challenge provider's specific options.
         :param pulumi.Input[str] certificate_domain: The common name of the certificate.
         :param pulumi.Input[str] certificate_not_after: The expiry date of the certificate, laid out in
                RFC3339 format (`2006-01-02T15:04:05Z07:00`).
@@ -621,6 +654,8 @@ class _CertificateState:
         """
         if account_key_pem is not None:
             pulumi.set(__self__, "account_key_pem", account_key_pem)
+        if cert_timeout is not None:
+            pulumi.set(__self__, "cert_timeout", cert_timeout)
         if certificate_domain is not None:
             pulumi.set(__self__, "certificate_domain", certificate_domain)
         if certificate_not_after is not None:
@@ -684,6 +719,23 @@ class _CertificateState:
     @account_key_pem.setter
     def account_key_pem(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "account_key_pem", value)
+
+    @property
+    @pulumi.getter(name="certTimeout")
+    def cert_timeout(self) -> Optional[pulumi.Input[int]]:
+        """
+        Controls the timeout in seconds for certificate requests
+        that are made after challenges are complete. Defaults to 30 seconds.
+
+        > As mentioned, `cert_timeout` does nothing until all challenges are complete.
+        If you are looking to control timeouts related to a particular challenge (such
+        as a DNS challenge), see that challenge provider's specific options.
+        """
+        return pulumi.get(self, "cert_timeout")
+
+    @cert_timeout.setter
+    def cert_timeout(self, value: Optional[pulumi.Input[int]]):
+        pulumi.set(self, "cert_timeout", value)
 
     @property
     @pulumi.getter(name="certificateDomain")
@@ -1078,6 +1130,7 @@ class Certificate(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  account_key_pem: Optional[pulumi.Input[str]] = None,
+                 cert_timeout: Optional[pulumi.Input[int]] = None,
                  certificate_p12_password: Optional[pulumi.Input[str]] = None,
                  certificate_request_pem: Optional[pulumi.Input[str]] = None,
                  common_name: Optional[pulumi.Input[str]] = None,
@@ -1103,6 +1156,12 @@ class Certificate(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] account_key_pem: The private key of the account that is
                requesting the certificate. Forces a new resource when changed.
+        :param pulumi.Input[int] cert_timeout: Controls the timeout in seconds for certificate requests
+               that are made after challenges are complete. Defaults to 30 seconds.
+               
+               > As mentioned, `cert_timeout` does nothing until all challenges are complete.
+               If you are looking to control timeouts related to a particular challenge (such
+               as a DNS challenge), see that challenge provider's specific options.
         :param pulumi.Input[str] certificate_p12_password: Password to be used when generating
                the PFX file stored in `certificate_p12`. Defaults to an
                empty string.
@@ -1220,6 +1279,7 @@ class Certificate(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  account_key_pem: Optional[pulumi.Input[str]] = None,
+                 cert_timeout: Optional[pulumi.Input[int]] = None,
                  certificate_p12_password: Optional[pulumi.Input[str]] = None,
                  certificate_request_pem: Optional[pulumi.Input[str]] = None,
                  common_name: Optional[pulumi.Input[str]] = None,
@@ -1250,6 +1310,7 @@ class Certificate(pulumi.CustomResource):
             if account_key_pem is None and not opts.urn:
                 raise TypeError("Missing required property 'account_key_pem'")
             __props__.__dict__["account_key_pem"] = None if account_key_pem is None else pulumi.Output.secret(account_key_pem)
+            __props__.__dict__["cert_timeout"] = cert_timeout
             __props__.__dict__["certificate_p12_password"] = None if certificate_p12_password is None else pulumi.Output.secret(certificate_p12_password)
             __props__.__dict__["certificate_request_pem"] = certificate_request_pem
             __props__.__dict__["common_name"] = common_name
@@ -1288,6 +1349,7 @@ class Certificate(pulumi.CustomResource):
             id: pulumi.Input[str],
             opts: Optional[pulumi.ResourceOptions] = None,
             account_key_pem: Optional[pulumi.Input[str]] = None,
+            cert_timeout: Optional[pulumi.Input[int]] = None,
             certificate_domain: Optional[pulumi.Input[str]] = None,
             certificate_not_after: Optional[pulumi.Input[str]] = None,
             certificate_p12: Optional[pulumi.Input[str]] = None,
@@ -1322,6 +1384,12 @@ class Certificate(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] account_key_pem: The private key of the account that is
                requesting the certificate. Forces a new resource when changed.
+        :param pulumi.Input[int] cert_timeout: Controls the timeout in seconds for certificate requests
+               that are made after challenges are complete. Defaults to 30 seconds.
+               
+               > As mentioned, `cert_timeout` does nothing until all challenges are complete.
+               If you are looking to control timeouts related to a particular challenge (such
+               as a DNS challenge), see that challenge provider's specific options.
         :param pulumi.Input[str] certificate_domain: The common name of the certificate.
         :param pulumi.Input[str] certificate_not_after: The expiry date of the certificate, laid out in
                RFC3339 format (`2006-01-02T15:04:05Z07:00`).
@@ -1439,6 +1507,7 @@ class Certificate(pulumi.CustomResource):
         __props__ = _CertificateState.__new__(_CertificateState)
 
         __props__.__dict__["account_key_pem"] = account_key_pem
+        __props__.__dict__["cert_timeout"] = cert_timeout
         __props__.__dict__["certificate_domain"] = certificate_domain
         __props__.__dict__["certificate_not_after"] = certificate_not_after
         __props__.__dict__["certificate_p12"] = certificate_p12
@@ -1474,6 +1543,19 @@ class Certificate(pulumi.CustomResource):
         requesting the certificate. Forces a new resource when changed.
         """
         return pulumi.get(self, "account_key_pem")
+
+    @property
+    @pulumi.getter(name="certTimeout")
+    def cert_timeout(self) -> pulumi.Output[Optional[int]]:
+        """
+        Controls the timeout in seconds for certificate requests
+        that are made after challenges are complete. Defaults to 30 seconds.
+
+        > As mentioned, `cert_timeout` does nothing until all challenges are complete.
+        If you are looking to control timeouts related to a particular challenge (such
+        as a DNS challenge), see that challenge provider's specific options.
+        """
+        return pulumi.get(self, "cert_timeout")
 
     @property
     @pulumi.getter(name="certificateDomain")


### PR DESCRIPTION
This PR was generated via `$ upgrade-provider pulumiverse/pulumi-acme --kind provider --target-version v2.18.0`.

---

- Upgrading terraform-provider-acme from 2.17.1  to 2.18.0.
